### PR TITLE
Changing backup filepath as the model reference

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,8 @@ module.exports = {
         return {
             upload: (file) => {
                 return new Promise((resolve, reject) => {
-                    const filePath = file.path ? `${file.path}/` : `${file.hash}/`;
+                    const backupPath = file.related[0].ref ? `${file.related[0].ref}` : `${file.hash}`
+                    const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
                     const fileName = slugify(path.basename(file.name, file.ext)) + file.ext.toLowerCase();
 
                     checkBucket(GCS, config.bucketName, config.bucketLocation)


### PR DESCRIPTION
putting the file hash as fall-through backup.

Overall the goal is to clean up the folder system on the bucket, each model will have it's own folder, making storage a lot cleaner by default. If some version update happens where that path no longer works, the file path will go back to file hash as last resort.