### PR TITLE
Added chooser to allow usage of domain-named buckets.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ const checkBucket = async (GCS, bucketName, bucketLocation) => {
 
 /**
  *
- * @type {{init: (function(*=): {upload: (function(*): Promise<any>)}), checkServiceAccount: module.exports.checkServiceAccount, provider: string, auth: {bucketName: {label: string, type: string}, bucketLocation: {values: string[], label: string, type: string}, serviceAccount: {label: string, type: string}}, checkBucket: module.exports.checkBucket, name: string}}
+ * @type {{init: (function(*=): {upload: (function(*): Promise<any>)}), checkServiceAccount: module.exports.checkServiceAccount, provider: string, auth: {bucketName: {label: string, type: string}, bucketLocation: {values: string[], label: string, type: string}, serviceAccount: {label: string, type: string}, baseUrl: {values: string[], label: string, type: string}}}, checkBucket: module.exports.checkBucket, name: string}}
  */
 module.exports = {
     provider: 'google-cloud-storage',
@@ -99,6 +99,15 @@ module.exports = {
                 'asia',
                 'eu',
                 'us'
+            ]
+        },
+        baseUrl: {
+            label: 'Use bucket name as base URL (https://cloud.google.com/storage/docs/domain-name-verification)',
+            type: 'enum',
+            values: [
+                'https://storage.googleapis.com/{bucket-name}',
+                'https://{bucket-name}',
+                'http://{bucket-name}'
             ]
         }
     },
@@ -168,7 +177,7 @@ module.exports = {
                             }
                         )
                         .then(() => {
-                            file.url = `https://storage.googleapis.com/${config.bucketName}/${filePath}${fileName}`;
+                            file.url = `${config.baseUrl.replace(/{bucket-name}/, config.bucketName)}/${filePath}${fileName}`;
                             strapi.log.debug(`File successfully uploaded to ${file.url}`);
                             resolve();
                         })


### PR DESCRIPTION
This was the most easy-to-use approach I could think, as there apparently is no "optional" or non-required form field available.

It allows using domain-named buckets as the actual domain for the view/download path (https://cloud.google.com/storage/docs/domain-name-verification).

Feedback appreciated of course.