### PR TITLE
ensuring safe storage for files with same name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const path = require('path');
 const {Storage} = require('@google-cloud/storage');
-const slugify = require('slugify');
 
 /**
  * Check validity of Service Account configuration
@@ -126,7 +124,7 @@ module.exports = {
                 return new Promise((resolve, reject) => {
                     const backupPath = file.related && file.related.length > 0 && file.related[0].ref ? `${file.related[0].ref}` : `${file.hash}`
                     const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
-                    const fileName = slugify(path.basename(file.name, file.ext)) + file.ext.toLowerCase();
+                    const fileName = file.hash + file.ext.toLowerCase();
 
                     checkBucket(GCS, config.bucketName, config.bucketLocation)
                     .then(() => {
@@ -190,7 +188,7 @@ module.exports = {
             delete: (file) => {
                 return new Promise((resolve, reject) => {
                     const filePath = file.path ? `${file.path}/` : `${file.hash}/`;
-                    const fileName = slugify(path.basename(file.name, file.ext)) + file.ext.toLowerCase();
+                    const fileName = file.hash + file.ext.toLowerCase();
 
                     GCS
                     .bucket(config.bucketName)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/Lith/strapi-provider-upload-google-cloud-storage#readme",
   "dependencies": {
-    "@google-cloud/storage": "^3.0.3",
-    "slugify": "^1.3.4"
+    "@google-cloud/storage": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-upload-google-cloud-storage",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0-beta.18",
   "description": "(Non-official) Google Cloud Storage Provider for Strapi Upload",
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
First thing first: thanks @Lith for your work on that one ❤️ 

---

### What this PR does

The `fileName` is being taken from the `file.name` argument attribute. This is great to get in GCS the same file name as the local computer which uploaded it. But, the side effect is that if you upload an image with the same name (even if it's different, coming from another local folder), it will overwrite an existing, legit image in GCS 😱 

This behaviour is avoided in [strapi-provider-upload-local](https://github.com/strapi/strapi/blob/master/packages/strapi-provider-upload-local/lib/index.js#L19) and [strapi-provider-upload-aws-s3](https://github.com/strapi/strapi/blob/master/packages/strapi-provider-upload-aws-s3/lib/index.js#L78) by simply using the `file.hash` argument attribute.

That removes the need for the `slugify` dependency. Besides, I've used this package with great success on strapi `3.0.0-beta.18.3`, it is totally safe to be bumped up 👌 