### PR TITLE
fix unrecognized serviceAccountJSON frm GCP

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,30 +14,30 @@ const checkConfig = (config) => {
     let newConfig = config;
     if (strapi.config.gcs) {
         if (strapi.config.gcs.serviceAccount) {
-            config.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
+            newConfig.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
         }
         if (strapi.config.gcs.bucketName) {
-            config.bucketName = trimParam(strapi.config.gcs.bucketName);
+            newConfig.bucketName = trimParam(strapi.config.gcs.bucketName);
         }
         if (strapi.config.gcs.bucketLocation) {
-            config.bucketLocation = trimParam(strapi.config.gcs.bucketLocation);
+            newConfig.bucketLocation = trimParam(strapi.config.gcs.bucketLocation);
         }
         if (strapi.config.gcs.baseUrl) {
-            config.baseUrl = trimParam(strapi.config.gcs.baseUrl);
+            newConfig.baseUrl = trimParam(strapi.config.gcs.baseUrl);
         }
     }
     if (strapi.config.currentEnvironment.gcs) {
         if (strapi.config.currentEnvironment.gcs.serviceAccount) {
-            config.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
+            newConfig.serviceAccount = trimParam(strapi.config.currentEnvironment.gcs.serviceAccount);
         }
         if (strapi.config.currentEnvironment.gcs.bucketName) {
-            config.bucketName = trimParam(strapi.config.gcs.bucketName);
+            newConfig.bucketName = trimParam(strapi.config.currentEnvironment.gcs.bucketName);
         }
         if (strapi.config.currentEnvironment.gcs.bucketLocation) {
-            config.bucketLocation = trimParam(strapi.config.gcs.bucketLocation);
+            newConfig.bucketLocation = trimParam(strapi.config.currentEnvironment.gcs.bucketLocation);
         }
         if (strapi.config.currentEnvironment.gcs.baseUrl) {
-            config.baseUrl = trimParam(strapi.config.gcs.baseUrl);
+            newConfig.baseUrl = trimParam(strapi.config.currentEnvironment.gcs.baseUrl);
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@
 
 const _ = require('lodash');
 const {Storage} = require('@google-cloud/storage');
-const trimParam = str => (typeof str === 'string' ? str.trim() : undefined);
+const trimParam = inVar => (typeof inVar === 'string' ? inVar.trim() : 
+    typeof invar === 'object' ? invar : undefined);
 
 /**
  * Load config from environment variable (if provided)
@@ -47,7 +48,8 @@ const checkServiceAccount = (config) => {
         );
     }
     try {
-        const serviceAccount = JSON.parse(config.serviceAccount);
+        const serviceAccount = typeof config.serviceAccount === 'string' ? JSON.parse(config.serviceAccount) :
+            typeof config.serviceAccount === 'object' ? config.serviceAccount : undefined;
         /**
          * Check exist
          */

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,6 @@ const trimParam = inVar => (typeof inVar === 'string' ? inVar.trim() :
  */
 const checkConfig = (config) => {
     let newConfig = config;
-
     if (strapi.config.gcs) {
         if (strapi.config.gcs.serviceAccount) {
             config.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
@@ -24,6 +23,20 @@ const checkConfig = (config) => {
             config.bucketLocation = trimParam(strapi.config.gcs.bucketLocation);
         }
         if (strapi.config.gcs.baseUrl) {
+            config.baseUrl = trimParam(strapi.config.gcs.baseUrl);
+        }
+    }
+    if (strapi.config.gcs) {
+        if (strapi.config.currentEnvironment.gcs.serviceAccount) {
+            config.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
+        }
+        if (strapi.config.currentEnvironment.gcs.bucketName) {
+            config.bucketName = trimParam(strapi.config.gcs.bucketName);
+        }
+        if (strapi.config.currentEnvironment.gcs.bucketLocation) {
+            config.bucketLocation = trimParam(strapi.config.gcs.bucketLocation);
+        }
+        if (strapi.config.currentEnvironment.gcs.baseUrl) {
             config.baseUrl = trimParam(strapi.config.gcs.baseUrl);
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const checkConfig = (config) => {
             config.baseUrl = trimParam(strapi.config.gcs.baseUrl);
         }
     }
-    if (strapi.config.gcs) {
+    if (strapi.config.currentEnvironment.gcs) {
         if (strapi.config.currentEnvironment.gcs.serviceAccount) {
             config.serviceAccount = trimParam(strapi.config.gcs.serviceAccount);
         }


### PR DESCRIPTION
I hunted down to how the trimParam function actually throw away objects being inputted. This variable sanitizing with assertion of string, together with parsing to JSON (from string), results in error when `serviceAccount` is defined as object in `providerOptions` or inside `gcs` key inside `strapi.config`. However, this would need the documentation to be updated. Apparently this would solve my issue #23 

#22 really helped clarifying how to add the *Service account JSON*, but stringifying the JSON file while it can be validly pasted inside JSON (as sub-object) looks like a hurdle.