### PR TITLE
Merge gcs key in strapi custom config into plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ yarn install strapi-provider-upload-google-cloud-storage
 
 ## Create your Bucket on Google Cloud Storage
 
+The bucket should be created with **fine grained** access control, as the plugin will configure uploaded files with public read access.
+
 ## Setting up Google authentification
 
 1. In the GCP Console, go to the **Create service account key** page.. 
@@ -105,6 +107,32 @@ else {
   module.exports = {
     provider: 'local'
   };
+}
+```
+
+**Overriding `uploadProvider` config with `gcs` key in Strapi custom config**
+
+Contents of `gcs` key in Strapi custom config, if set, will be merged over `./extensions/upload/config/settings.json`,
+
+`./config/custom.json` (config items set here will be merged over, overriding config set at `./extensions/upload/config/settings.json`)
+```json
+{
+  "gcs" : {
+    "serviceAccount": "<Your serviceAccount JSON object here>",
+    "bucketName": "Bucket-name",
+    "baseUrl": "https://storage.googleapis.com/{bucket-name}"
+  }
+}
+```
+
+`./config/environments/<development|staging|production>/custom.json` (config items set here will be merged over and override the previous ones)
+```json
+{
+  "gcs" : {
+    "serviceAccount": "<Your serviceAccount JSON object here>",
+    "bucketName": "Bucket-name",
+    "baseUrl": "https://storage.googleapis.com/{bucket-name}"
+  }
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,10 +66,10 @@ const checkBucket = async (GCS, bucketName) => {
         if (!data[0]) {
             throw new Error(
                 'An error occurs when we try to retrieve the Bucket "' + bucketName + '". Check if bucket exist on Google Cloud Platform.'
-                );
-            }
-        });
-    };
+            );
+        }
+    });
+};
     
 /**
  * Merge uploadProvider config with gcs key in custom Strapi config

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,17 +66,29 @@ const checkBucket = async (GCS, bucketName) => {
         if (!data[0]) {
             throw new Error(
                 'An error occurs when we try to retrieve the Bucket "' + bucketName + '". Check if bucket exist on Google Cloud Platform.'
-            );
-        }
-    });
-};
+                );
+            }
+        });
+    };
+    
+/**
+ * Merge uploadProvider config with gcs key in custom Strapi config
+ * @param uploadProviderConfig
+ * @returns {{private_key}|{client_email}|{project_id}|any}
+ */
+const mergeConfigs = providerConfig => {
+    let customGcsConfig = strapi.config.gcs ? strapi.config.gcs : {}
+    let customEnvGcsConfig = strapi.config.currentEnvironment.gcs ? strapi.config.currentEnvironment.gcs : {}
+    return {...providerConfig, ...customGcsConfig, ...customEnvGcsConfig}
+}
 
 /**
  *
  * @type {{init(*=): {upload(*=): Promise<unknown>, delete(*): Promise<unknown>}}}
  */
 module.exports = {
-    init(config) {
+    init(providerConfig) {
+        const config = mergeConfigs(providerConfig)
         const serviceAccount = checkServiceAccount(config);
         const GCS = new Storage({
             projectId: serviceAccount.project_id,


### PR DESCRIPTION
This allows easier switching of configuration by environment variables (detailed in `readme.md`).

I also added in readme that the storage bucket to be used should use fine-grained access control (uniform access control won't work as the plugin set uploaded files to have public access).