### PR TITLE
add publicFiles variable to define publicity of upload files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ You will find below many examples of configurations, for each example :
   "providerOptions": {
     "serviceAccount": "<Your serviceAccount JSON object/string here>",
     "bucketName": "Bucket-name",
-    "baseUrl": "https://storage.googleapis.com/{bucket-name}"
+    "baseUrl": "https://storage.googleapis.com/{bucket-name}",
+    "publicFiles": true
   }
 }
 ```
@@ -73,7 +74,8 @@ You will find below many examples of configurations, for each example :
   "providerOptions": {
     "serviceAccount": "${process.env.GCS_SERVICE_ACCOUNT || <Your serviceAccount JSON object/string here>}",
     "bucketName": "${process.env.GCS_BUCKET_NAME || Bucket-name}",
-    "baseUrl": "${process.env.GCS_BASE_URL || https://storage.googleapis.com/{bucket-name}}"
+    "baseUrl": "${process.env.GCS_BASE_URL || https://storage.googleapis.com/{bucket-name}}",
+    "publicFiles": true
   }
 }
 ```
@@ -87,14 +89,16 @@ All variable are optional, you can setting up only `bucketName` if you need to c
 ```js
 const stagingProviderOptions = {
   serviceAccount: '<Your serviceAccount JSON object/string here>', // json configuration 
-    bucketName: 'Bucket-name', // name of the bucket
-    baseUrl: 'https://storage.googleapis.com/{bucket-name}'
+  bucketName: 'Bucket-name', // name of the bucket
+  baseUrl: 'https://storage.googleapis.com/{bucket-name}',
+  publicFiles: false
 };
 
 const productionProviderOptions = {
   serviceAccount: '<Your serviceAccount JSON object/string here>', // json configuration 
   bucketName: 'Bucket-name', // name of the bucket
-  baseUrl: 'https://storage.googleapis.com/{bucket-name}'
+  baseUrl: 'https://storage.googleapis.com/{bucket-name}',
+  publicFiles: true
 };
 
 
@@ -127,7 +131,8 @@ Contents of `gcs` key in Strapi custom config, if set, will be merged over `./ex
   "gcs" : {
     "serviceAccount": "<Your serviceAccount JSON object/string here>",
     "bucketName": "Bucket-name",
-    "baseUrl": "https://storage.googleapis.com/{bucket-name}"
+    "baseUrl": "https://storage.googleapis.com/{bucket-name}",
+    "publicFiles": true
   }
 }
 ```
@@ -138,7 +143,8 @@ Contents of `gcs` key in Strapi custom config, if set, will be merged over `./ex
   "gcs" : {
     "serviceAccount": "<Your serviceAccount JSON object/string here>",
     "bucketName": "Bucket-name",
-    "baseUrl": "https://storage.googleapis.com/{bucket-name}"
+    "baseUrl": "https://storage.googleapis.com/{bucket-name}",
+    "publicFiles": true
   }
 }
 ```
@@ -162,6 +168,10 @@ Define your base Url, first is default value :
 - https://storage.googleapis.com/{bucket-name}
 - https://{bucket-name}
 - http://{bucket-name}
+
+#### `publicFiles`:
+
+Boolean atribute to define public attribute to file when it is upload to storage.
 
 ## Important information
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -20,6 +20,9 @@ const checkServiceAccount = (config) => {
     /** Set to default **/
     config.baseUrl = 'https://storage.googleapis.com/{bucket-name}';
   }
+  if (config.publicFiles === undefined) {
+    config.publicFiles = true;
+  }
 
   let serviceAccount;
 
@@ -154,7 +157,7 @@ const init = (providerConfig) => {
               .file(`${filePath}${fileName}`)
               .save(file.buffer, {
                 contentType: file.mime,
-                public: true,
+                public: config.publicFiles,
                 metadata: {
                   contentDisposition: `inline; filename="${file.name}"`,
                 },


### PR DESCRIPTION
It refers to #31 

Just need to remember, your strapi instance can not have authorization to access the bucket object.

![image](https://user-images.githubusercontent.com/94767/83138430-251cd400-a0c1-11ea-9099-3d4900fe4467.png)

In above example, the left image is non public and the right one is public.

Changing the *new* attribute "publicFiles" do `false`.

![image](https://user-images.githubusercontent.com/94767/83025191-49b37600-a005-11ea-8a99-af3e08218979.png)

Changing the *new* attribute "publicFiles" do `true`.

![image](https://user-images.githubusercontent.com/94767/83025621-69e33500-a005-11ea-86ed-570e74e7dffa.png)

Leaving it without define "publicFiles" attribute.

![image](https://user-images.githubusercontent.com/94767/83027035-faba1080-a005-11ea-8ba5-b11beefafa95.png)
