### PR TITLE
fix undefined variable using a port for lodash/underscore.get

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -5,6 +5,26 @@ const slugify = require('slugify');
 const { Storage } = require('@google-cloud/storage');
 
 /**
+ * lodash _.get native port
+ *
+ * checkout: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
+ *
+ * Another solution is use destructor variable with default value as {} on each layer
+ * but it appears so tricky.
+ *
+ * const { a: { b: { c: d = 42 } = {} } = {} } = object
+ */
+const get = (obj, path, defaultValue = undefined) => {
+  const travel = (regexp) =>
+    String.prototype.split
+      .call(path, regexp)
+      .filter(Boolean)
+      .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+  const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+  return result === undefined || result === obj ? defaultValue : result;
+};
+
+/**
  * Check validity of Service Account configuration
  * @param config
  * @returns {{private_key}|{client_email}|{project_id}|any}
@@ -81,10 +101,8 @@ const checkBucket = async (GCS, bucketName) => {
  * @returns {{private_key}|{client_email}|{project_id}|any}
  */
 const mergeConfigs = (providerConfig) => {
-  let customGcsConfig = strapi.config.gcs ? strapi.config.gcs : {};
-  let customEnvGcsConfig = strapi.config.currentEnvironment.gcs
-    ? strapi.config.currentEnvironment.gcs
-    : {};
+  const customGcsConfig = get(strapi, 'config.gcs', {});
+  const customEnvGcsConfig = get(strapi, 'config.currentEnvironment.gcs', {});
   return { ...providerConfig, ...customGcsConfig, ...customEnvGcsConfig };
 };
 
@@ -199,6 +217,7 @@ const init = (providerConfig) => {
 };
 
 module.exports = {
+  get,
   checkServiceAccount,
   checkBucket,
   mergeConfigs,


### PR DESCRIPTION
Refs #43 

This will port the provider to use on both versions: `3.0.0-beta.x` and `3.0.x` (stable version).