### PR TITLE
allow uniform access control and remove check bucket

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -83,25 +83,6 @@ const checkServiceAccount = (config) => {
 };
 
 /**
- * Check bucket exist, or create it
- * @param GCS
- * @param bucketName
- * @returns {Promise<void>}
- */
-const checkBucket = async (GCS, bucketName) => {
-  let bucket = GCS.bucket(bucketName);
-  await bucket.exists().then((data) => {
-    if (!data[0]) {
-      throw new Error(
-        'An error occurs when we try to retrieve the Bucket "' +
-          bucketName +
-          '". Check if bucket exist on Google Cloud Platform.'
-      );
-    }
-  });
-};
-
-/**
  * Merge uploadProvider config with gcs key in custom Strapi config
  * @param uploadProviderConfig
  * @returns {{private_key}|{client_email}|{project_id}|any}
@@ -138,63 +119,24 @@ const init = (providerConfig) => {
         const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
         const fileName =
           slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
-
-        checkBucket(GCS, config.bucketName)
-          .then(() => {
-            /**
-             * Check if the file already exist and force to remove it on Bucket
-             */
-            GCS.bucket(config.bucketName)
-              .file(`${basePath}${filePath}${fileName}`)
-              .exists()
-              .then((exist) => {
-                if (exist[0]) {
-                  strapi.log.info('File already exist, try to remove it.');
-                  const fileName = `${file.url.replace(
-                    config.baseUrl.replace('{bucket-name}', config.bucketName) + '/',
-                    ''
-                  )}`;
-
-                  GCS.bucket(config.bucketName)
-                    .file(`${fileName}`)
-                    .delete()
-                    .then(() => {
-                      strapi.log.debug(`File ${fileName} successfully deleted`);
-                    })
-                    .catch((error) => {
-                      if (error.code === 404) {
-                        return strapi.log.warn(
-                          'Remote file was not found, you may have to delete manually.'
-                        );
-                      }
-                    });
-                }
-              });
+        GCS.bucket(config.bucketName)
+          .file(`${filePath}${fileName}`)
+          .save(file.buffer, {
+            contentType: file.mime,
+            metadata: {
+              contentDisposition: `inline; filename="${file.name}"`,
+            },
           })
           .then(() => {
-            /**
-             * Then save file
-             */
-            GCS.bucket(config.bucketName)
-              .file(`${basePath}${filePath}${fileName}`)
-              .save(file.buffer, {
-                contentType: file.mime,
-                public: config.publicFiles,
-                metadata: {
-                  contentDisposition: `inline; filename="${file.name}"`,
-                },
-              })
-              .then(() => {
-                file.url = `${config.baseUrl.replace(
-                  /{bucket-name}/,
-                  config.bucketName
-                )}/${basePath}${filePath}${fileName}`;
-                strapi.log.debug(`File successfully uploaded to ${file.url}`);
-                resolve();
-              })
-              .catch((error) => {
-                return reject(error);
-              });
+            file.url = `${config.baseUrl.replace(
+              /{bucket-name}/,
+              config.bucketName
+            )}/${filePath}${fileName}`;
+            strapi.log.debug(`File successfully uploaded to ${file.url}`);
+            resolve();
+          })
+          .catch((error) => {
+            return reject(error);
           });
       });
     },
@@ -226,7 +168,6 @@ const init = (providerConfig) => {
 module.exports = {
   get,
   checkServiceAccount,
-  checkBucket,
   mergeConfigs,
   init,
 };


### PR DESCRIPTION
I think user always create bucket when using gcs so check bucket is not requires. With fine grained access control, i just remove public true in options when you upload file. I also remove check file exist because if exist, gcs always create new file for us with uid after file. Uniform access control is recommend by gcs when you create new bucket. I think we should follow it

Thanks 