### PR TITLE
Enhancement/short file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ Define base path to save each media document.
 
 Boolean atribute to define public attribute to file when it is upload to storage.
 
+#### `shortFilePaths`:
+
+A boolean attribute (default is `false` - the default version).
+
+When set to `false` each uploaded file will be stored in its own directory. Hence with 
+auto-resizing of images enabled -> One image upload will result in up to 5 images each 
+in its own directory.
+
+When set to `true` all resized version of one image will be in the same directory. There
+will still be one distinct directory for each image regardless of whether auto-resizing
+is turned on or off.
+
+*This latter setting is new and works for the Strapi standard settings. However, it
+might not work yet when interfering with the upload process manually.*
+
 ## Important information
 
 From release `3.0.0-beta.20` the `bucketLocation` is no longer supported.

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -150,6 +150,7 @@ const generateUploadFileName = (basePath, file, shortFilePaths) => {
     if (!fileDirectory) {
       fileDirectory = fileName;
     }
+    fileDirectory = path.basename(fileDirectory, file.ext);
 
     return `${basePath}${fileDirectory}/${fileName}`;
   }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -116,10 +116,8 @@ const mergeConfigs = (providerConfig) => {
  * @returns string
  */
 const generateUploadFileName = (basePath, file, shortFilePaths) => {
-
   if (!shortFilePaths) {
     // Default version
-
     const backupPath =
       file.related && file.related.length > 0 && file.related[0].ref
         ? `${file.related[0].ref}`
@@ -129,29 +127,24 @@ const generateUploadFileName = (basePath, file, shortFilePaths) => {
     // make sure that the extension is correct and the filename is valid:
     // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
     // slugify -> https://www.npmjs.com/package/slugify
-    const fileName = slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
+    const fileName =
+      slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
 
     return `${basePath}${filePath}${fileName}`;
-
   } else {
     // New version with more intuitive subdirectories
-
     // make sure that the extension is correct and the filename is valid:
     // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
     // slugify -> https://www.npmjs.com/package/slugify
-    const fileName = slugify(
-      path.basename(file.hash, file.ext),
-      {
-        replacement: '-',
-        remove: /[*+~.()'"!:@]/g
-      }
-    ) + file.ext.toLowerCase();
+    const fileName =
+      slugify(path.basename(file.hash, file.ext), { replacement: '-', remove: /[*+~.()'"!:@]/g }) +
+      file.ext.toLowerCase();
 
     // Place all resized version of an image into one directory named after the original image
     let fileDirectory = undefined;
-    ["thumbnail_", "small_", "medium_", "large_"].forEach(prefix => {
+    ['thumbnail_', 'small_', 'medium_', 'large_'].forEach((prefix) => {
       if (fileName.startsWith(prefix)) {
-        fileDirectory = fileName.replace(prefix, "");
+        fileDirectory = fileName.replace(prefix, '');
       }
     });
     if (!fileDirectory) {
@@ -182,7 +175,11 @@ const init = (providerConfig) => {
   return {
     async upload(file) {
       try {
-        const fullFileName = generateUploadFileName(basePath, file, providerConfig.shortFilePaths === true);
+        const fullFileName = generateUploadFileName(
+          basePath,
+          file,
+          providerConfig.shortFilePaths === true
+        );
         await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -115,15 +115,51 @@ const mergeConfigs = (providerConfig) => {
  * @param file
  * @returns string
  */
-const generateUploadFileName = (basePath, file) => {
-  const backupPath =
-    file.related && file.related.length > 0 && file.related[0].ref
-      ? `${file.related[0].ref}`
-      : `${file.hash}`;
-  const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
-  const extension = file.ext.toLowerCase();
-  const fileName = slugify(path.basename(file.name + '_' + file.hash, file.ext)) + extension;
-  return `${basePath}${filePath}${fileName}`;
+const generateUploadFileName = (basePath, file, shortFilePaths) => {
+
+  if (!shortFilePaths) {
+    // Default version
+
+    const backupPath =
+      file.related && file.related.length > 0 && file.related[0].ref
+        ? `${file.related[0].ref}`
+        : `${file.hash}`;
+    const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
+
+    // make sure that the extension is correct and the filename is valid:
+    // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
+    // slugify -> https://www.npmjs.com/package/slugify
+    const fileName = slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
+
+    return `${basePath}${filePath}${fileName}`;
+
+  } else {
+    // New version with more intuitive subdirectories
+
+    // make sure that the extension is correct and the filename is valid:
+    // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
+    // slugify -> https://www.npmjs.com/package/slugify
+    const fileName = slugify(
+      path.basename(file.hash, file.ext),
+      {
+        replacement: '-',
+        remove: /[*+~.()'"!:@]/g
+      }
+    ) + file.ext.toLowerCase();
+
+    // Place all resized version of an image into one directory named after the original image
+    let fileDirectory = undefined;
+    ["thumbnail_", "small_", "medium_", "large_"].forEach(prefix => {
+      if (fileName.startsWith(prefix)) {
+        fileDirectory = fileName.replace(prefix, "");
+      }
+    });
+    if (!fileDirectory) {
+      fileDirectory = fileName;
+    }
+
+    return `${basePath}${fileDirectory}/${fileName}`;
+  }
 };
 
 /**
@@ -146,7 +182,7 @@ const init = (providerConfig) => {
   return {
     async upload(file) {
       try {
-        const fullFileName = generateUploadFileName(basePath, file);
+        const fullFileName = generateUploadFileName(basePath, file, providerConfig.shortFilePaths === true);
         await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -116,22 +116,7 @@ const mergeConfigs = (providerConfig) => {
  * @returns string
  */
 const generateUploadFileName = (basePath, file, shortFilePaths) => {
-  if (!shortFilePaths) {
-    // Default version
-    const backupPath =
-      file.related && file.related.length > 0 && file.related[0].ref
-        ? `${file.related[0].ref}`
-        : `${file.hash}`;
-    const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
-
-    // make sure that the extension is correct and the filename is valid:
-    // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
-    // slugify -> https://www.npmjs.com/package/slugify
-    const fileName =
-      slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
-
-    return `${basePath}${filePath}${fileName}`;
-  } else {
+  if (shortFilePaths) {
     // New version with more intuitive subdirectories
     // make sure that the extension is correct and the filename is valid:
     // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
@@ -141,19 +126,28 @@ const generateUploadFileName = (basePath, file, shortFilePaths) => {
       file.ext.toLowerCase();
 
     // Place all resized version of an image into one directory named after the original image
-    let fileDirectory = undefined;
-    ['thumbnail_', 'small_', 'medium_', 'large_'].forEach((prefix) => {
-      if (fileName.startsWith(prefix)) {
-        fileDirectory = fileName.replace(prefix, '');
-      }
-    });
-    if (!fileDirectory) {
-      fileDirectory = fileName;
-    }
-    fileDirectory = path.basename(fileDirectory, file.ext);
+    let fileDirectory = path.basename(
+      fileName.replace(/(thumbnail_|small_|medium_|large_)/g, ''),
+      file.ext
+    );
 
     return `${basePath}${fileDirectory}/${fileName}`;
   }
+
+  // Default version
+  const backupPath =
+    file.related && file.related.length > 0 && file.related[0].ref
+      ? `${file.related[0].ref}`
+      : `${file.hash}`;
+  const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
+
+  // make sure that the extension is correct and the filename is valid:
+  // path.basename -> https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext
+  // slugify -> https://www.npmjs.com/package/slugify
+  const fileName =
+    slugify(path.basename(file.name + '_' + file.hash, file.ext)) + file.ext.toLowerCase();
+
+  return `${basePath}${filePath}${fileName}`;
 };
 
 /**
@@ -179,7 +173,7 @@ const init = (providerConfig) => {
         const fullFileName = generateUploadFileName(
           basePath,
           file,
-          providerConfig.shortFilePaths === true
+          config.shortFilePaths === true
         );
         await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -273,408 +273,375 @@ describe('/lib/provider.js', () => {
     });
   });
 
-  describe('#generateUploadFileName', () => {
-    it('must save filename in right name', async () => {
-      const testData = [
-        [
-          '',
-          'christopher-campbell_df9a53d774/christopher-campbell_christopher-campbell_df9a53d774.jpeg',
-          {
-            name: 'christopher-campbell',
-            alternativeText: undefined,
-            caption: undefined,
-            hash: 'christopher-campbell_df9a53d774',
-            ext: '.jpeg',
-            mime: 'image/jpeg',
-            size: 823.58,
-            width: 5184,
-            height: 3456,
-            buffer: 'file buffer information',
-          },
-        ],
-        [
-          '',
-          'thumbnail_christopher-campbell_df9a53d774/undefined_thumbnail_christopher-campbell_df9a53d774.jpeg',
-          {
-            hash: 'thumbnail_christopher-campbell_df9a53d774',
-            ext: '.jpeg',
-            mime: 'image/jpeg',
-            width: 234,
-            height: 156,
-            size: 5.53,
-            buffer: 'file buffer information',
-            path: null,
-          },
-        ],
-        [
-          'base-path/',
-          'base-path/galleries/boris-smokrovic_boris-smokrovic_9fd5439b3e.jpeg',
-          {
-            name: 'boris-smokrovic',
-            alternativeText: undefined,
-            caption: undefined,
-            hash: 'boris-smokrovic_9fd5439b3e',
-            ext: '.jpeg',
-            mime: 'image/jpeg',
-            size: 897.78,
-            related: [{ refId: '1', ref: 'galleries', source: undefined, field: 'cover' }],
-            width: 4373,
-            height: 2915,
-            buffer: 'file buffer data',
-          },
-        ],
-        [
-          'root/child/',
-          'root/child/thumbnail_boris-smokrovic_9fd5439b3e/undefined_thumbnail_boris-smokrovic_9fd5439b3e.jpeg',
-          {
-            hash: 'thumbnail_boris-smokrovic_9fd5439b3e',
-            ext: '.jpeg',
-            mime: 'image/jpeg',
-            width: 234,
-            height: 156,
-            size: 8.18,
-            buffer: 'file buffer data',
-            path: null,
-          },
-        ],
-      ];
+  [true, false].forEach((shortFilePaths) => {
+    describe('#generateUploadFileName', () => {
+      it(`must save filename in right name (shortFilePaths = ${shortFilePaths})`, async () => {
+        const testData = [
+          [
+            '',
+            'christopher-campbell_df9a53d774/christopher-campbell_christopher-campbell_df9a53d774.jpeg',
+            'christopher-campbell_df9a53d774/christopher-campbell_df9a53d774.jpeg',
+            {
+              name: 'christopher-campbell',
+              alternativeText: undefined,
+              caption: undefined,
+              hash: 'christopher-campbell_df9a53d774',
+              ext: '.jpeg',
+              mime: 'image/jpeg',
+              size: 823.58,
+              width: 5184,
+              height: 3456,
+              buffer: 'file buffer information',
+            },
+          ],
+          [
+            '',
+            'thumbnail_christopher-campbell_df9a53d774/undefined_thumbnail_christopher-campbell_df9a53d774.jpeg',
+            'christopher-campbell_df9a53d774/thumbnail_christopher-campbell_df9a53d774.jpeg',
+            {
+              hash: 'thumbnail_christopher-campbell_df9a53d774',
+              ext: '.jpeg',
+              mime: 'image/jpeg',
+              width: 234,
+              height: 156,
+              size: 5.53,
+              buffer: 'file buffer information',
+              path: null,
+            },
+          ],
+          [
+            'base-path/',
+            'base-path/galleries/boris-smokrovic_boris-smokrovic_9fd5439b3e.jpeg',
+            'base-path/boris-smokrovic_9fd5439b3e/boris-smokrovic_9fd5439b3e.jpeg',
+            {
+              name: 'boris-smokrovic',
+              alternativeText: undefined,
+              caption: undefined,
+              hash: 'boris-smokrovic_9fd5439b3e',
+              ext: '.jpeg',
+              mime: 'image/jpeg',
+              size: 897.78,
+              related: [{ refId: '1', ref: 'galleries', source: undefined, field: 'cover' }],
+              width: 4373,
+              height: 2915,
+              buffer: 'file buffer data',
+            },
+          ],
+          [
+            'root/child/',
+            'root/child/thumbnail_boris-smokrovic_9fd5439b3e/undefined_thumbnail_boris-smokrovic_9fd5439b3e.jpeg',
+            'root/child/boris-smokrovic_9fd5439b3e/thumbnail_boris-smokrovic_9fd5439b3e.jpeg',
+            {
+              hash: 'thumbnail_boris-smokrovic_9fd5439b3e',
+              ext: '.jpeg',
+              mime: 'image/jpeg',
+              width: 234,
+              height: 156,
+              size: 8.18,
+              buffer: 'file buffer data',
+              path: null,
+            },
+          ],
+        ];
 
-      const runTest = async ([basePath, expectedFileName, fileData]) => {
-        const generatedFileName = generateUploadFileName(basePath, fileData);
-        assert.equal(expectedFileName, generatedFileName);
-      };
+        const runTest = async ([
+          basePath,
+          expectedFileNameLong,
+          expectedFileNameShort,
+          fileData,
+        ]) => {
+          const generatedFileName = generateUploadFileName(basePath, fileData, shortFilePaths);
+          assert.equal(
+            generatedFileName,
+            shortFilePaths ? expectedFileNameShort : expectedFileNameLong
+          );
+        };
 
-      const promises = testData.map((data) => runTest(data));
-      await Promise.all(promises);
+        const promises = testData.map((data) => runTest(data));
+        await Promise.all(promises);
+      });
     });
   });
 
-  describe('#init', () => {
-    let strapiOriginal;
+  [true, false].forEach((shortFilePaths) => {
+    describe(`#init (shortFilePaths = ${shortFilePaths})`, () => {
+      let strapiOriginal;
 
-    beforeEach(() => {
-      strapiOriginal = global.strapi;
+      beforeEach(() => {
+        strapiOriginal = global.strapi;
 
-      global.strapi = {
-        config: {
-          currentEnvironment: {},
-        },
-        log: {
-          info() {},
-          debug() {},
-        },
-      };
-    });
+        global.strapi = {
+          config: {
+            currentEnvironment: {},
+          },
+          log: {
+            info() {},
+            debug() {},
+          },
+        };
+      });
 
-    afterEach(() => {
-      if (strapiOriginal === undefined) {
-        delete global.strapi;
-      } else {
-        global.strapi = strapiOriginal;
-      }
-    });
+      afterEach(() => {
+        if (strapiOriginal === undefined) {
+          delete global.strapi;
+        } else {
+          global.strapi = strapiOriginal;
+        }
+      });
 
-    it('must return an object with upload and delete methods', () => {
-      const config = {
-        serviceAccount: {
-          project_id: '123',
-          client_email: 'my@email.org',
-          private_key: 'a random key',
-        },
-        bucketName: 'any',
-      };
+      it('must return an object with upload and delete methods', () => {
+        const config = {
+          serviceAccount: {
+            project_id: '123',
+            client_email: 'my@email.org',
+            private_key: 'a random key',
+          },
+          bucketName: 'any',
+          shortFilePaths: shortFilePaths,
+        };
 
-      const result = init(config);
+        const result = init(config);
 
-      assert.ok(Object.keys(result).includes('upload'));
-      assert.equal(typeof result.upload, 'function');
-      assert.ok(Object.keys(result).includes('delete'));
-      assert.equal(typeof result.delete, 'function');
-    });
+        assert.ok(Object.keys(result).includes('upload'));
+        assert.equal(typeof result.upload, 'function');
+        assert.ok(Object.keys(result).includes('delete'));
+        assert.equal(typeof result.delete, 'function');
+      });
 
-    it('must instanciate google cloud storage with right configurations', () => {
-      let assertionsCount = 0;
-      mockRequire('@google-cloud/storage', {
-        Storage: class {
-          constructor(...args) {
-            assertionsCount += 1;
-            assert.deepEqual(args, [
-              {
-                credentials: {
+      it('must instanciate google cloud storage with right configurations', () => {
+        let assertionsCount = 0;
+        mockRequire('@google-cloud/storage', {
+          Storage: class {
+            constructor(...args) {
+              assertionsCount += 1;
+              assert.deepEqual(args, [
+                {
+                  credentials: {
+                    client_email: 'my@email.org',
+                    private_key: 'a random key',
+                  },
+                  projectId: '123',
+                },
+              ]);
+            }
+          },
+        });
+        const provider = mockRequire.reRequire('../../lib/provider');
+        const config = {
+          serviceAccount: {
+            project_id: '123',
+            client_email: 'my@email.org',
+            private_key: 'a random key',
+          },
+          bucketName: 'any',
+          shortFilePaths: shortFilePaths,
+        };
+        provider.init(config);
+        assert.equal(assertionsCount, 1);
+        mockRequire.stop('@google-cloud/storage');
+      });
+
+      describe('when execute #upload', () => {
+        let assertionsCount;
+
+        beforeEach(() => {
+          assertionsCount = 0;
+        });
+
+        describe('when bucket exists', () => {
+          const createBucketMock = ({ fileMock, expectedFileNames }) => ({
+            file(fileName) {
+              assertionsCount += 1;
+              assert.equal(fileName, expectedFileNames.shift());
+              return fileMock;
+            },
+            async exists() {
+              assertionsCount += 1;
+              return [true];
+            },
+          });
+
+          describe('when file DOES NOT exists in bucket', () => {
+            const createFileMock = ({ saveExpectedArgs }) => ({
+              async exists() {
+                assertionsCount += 1;
+                return [false];
+              },
+              async save(...args) {
+                assertionsCount += 1;
+                assert.deepEqual(args, saveExpectedArgs);
+                return [true];
+              },
+            });
+
+            it('must save file', async () => {
+              const fileData = {
+                ext: '.JPEG',
+                buffer: 'file buffer information',
+                mime: 'image/jpeg',
+                name: 'people coding.JPEG',
+                related: [
+                  {
+                    ref: 'ref',
+                  },
+                ],
+                hash: '4l0ngH45h',
+                path: '/tmp/strapi',
+              };
+
+              const saveExpectedArgs = [
+                'file buffer information',
+                {
+                  contentType: 'image/jpeg',
+                  metadata: {
+                    contentDisposition: 'inline; filename="people coding.JPEG"',
+                  },
+                  public: true,
+                },
+              ];
+
+              const fileMock = createFileMock({ saveExpectedArgs });
+              const expectedFileNames = [
+                '/tmp/strapi/people-coding.JPEG_4l0ngH45h.jpeg',
+                '/tmp/strapi/people-coding.JPEG_4l0ngH45h.jpeg',
+              ];
+              const bucketMock = createBucketMock({ fileMock, expectedFileNames });
+              const Storage = class {
+                bucket(bucketName) {
+                  assertionsCount += 1;
+                  assert.equal(bucketName, 'any bucket');
+                  return bucketMock;
+                }
+              };
+
+              mockRequire('@google-cloud/storage', { Storage });
+              const provider = mockRequire.reRequire('../../lib/provider');
+              const config = {
+                serviceAccount: {
+                  project_id: '123',
                   client_email: 'my@email.org',
                   private_key: 'a random key',
                 },
-                projectId: '123',
-              },
-            ]);
-          }
-        },
-      });
-      const provider = mockRequire.reRequire('../../lib/provider');
-      const config = {
-        serviceAccount: {
-          project_id: '123',
-          client_email: 'my@email.org',
-          private_key: 'a random key',
-        },
-        bucketName: 'any',
-      };
-      provider.init(config);
-      assert.equal(assertionsCount, 1);
-      mockRequire.stop('@google-cloud/storage');
-    });
-
-    describe('when execute #upload', () => {
-      let assertionsCount;
-
-      beforeEach(() => {
-        assertionsCount = 0;
-      });
-
-      describe('when bucket exists', () => {
-        const createBucketMock = ({ fileMock, expectedFileNames }) => ({
-          file(fileName) {
-            assertionsCount += 1;
-            assert.equal(fileName, expectedFileNames.shift());
-            return fileMock;
-          },
-          async exists() {
-            assertionsCount += 1;
-            return [true];
-          },
-        });
-
-        describe('when file DOES NOT exists in bucket', () => {
-          const createFileMock = ({ saveExpectedArgs }) => ({
-            async exists() {
-              assertionsCount += 1;
-              return [false];
-            },
-            async save(...args) {
-              assertionsCount += 1;
-              assert.deepEqual(args, saveExpectedArgs);
-              return [true];
-            },
+                bucketName: 'any bucket',
+                shortFilePaths: shortFilePaths,
+              };
+              const providerInstance = provider.init(config);
+              await providerInstance.upload(fileData);
+              assert.equal(assertionsCount, 6);
+              mockRequire.stop('@google-cloud/storage');
+            });
           });
 
-          it('must save file', async () => {
-            const fileData = {
-              ext: '.JPEG',
-              buffer: 'file buffer information',
-              mime: 'image/jpeg',
-              name: 'people coding.JPEG',
-              related: [
-                {
-                  ref: 'ref',
-                },
-              ],
-              hash: '4l0ngH45h',
-              path: '/tmp/strapi',
-            };
-
-            const saveExpectedArgs = [
-              'file buffer information',
-              {
-                contentType: 'image/jpeg',
-                metadata: {
-                  contentDisposition: 'inline; filename="people coding.JPEG"',
-                },
-                public: true,
-              },
-            ];
-
-            const fileMock = createFileMock({ saveExpectedArgs });
-            const expectedFileNames = [
-              '/tmp/strapi/people-coding.JPEG_4l0ngH45h.jpeg',
-              '/tmp/strapi/people-coding.JPEG_4l0ngH45h.jpeg',
-            ];
-            const bucketMock = createBucketMock({ fileMock, expectedFileNames });
-            const Storage = class {
-              bucket(bucketName) {
+          describe('when file exists in bucket', () => {
+            const createFileMock = ({ saveExpectedArgs }) => ({
+              async exists() {
                 assertionsCount += 1;
-                assert.equal(bucketName, 'any bucket');
-                return bucketMock;
-              }
-            };
-
-            mockRequire('@google-cloud/storage', { Storage });
-            const provider = mockRequire.reRequire('../../lib/provider');
-            const config = {
-              serviceAccount: {
-                project_id: '123',
-                client_email: 'my@email.org',
-                private_key: 'a random key',
+                return [true];
               },
-              bucketName: 'any bucket',
-            };
-            const providerInstance = provider.init(config);
-            await providerInstance.upload(fileData);
-            assert.equal(assertionsCount, 6);
-            mockRequire.stop('@google-cloud/storage');
-          });
-        });
-
-        describe('when file exists in bucket', () => {
-          const createFileMock = ({ saveExpectedArgs }) => ({
-            async exists() {
-              assertionsCount += 1;
-              return [true];
-            },
-            async delete() {
-              assertionsCount += 1;
-              return true;
-            },
-            async save(...args) {
-              assertionsCount += 1;
-              assert.deepEqual(args, saveExpectedArgs);
-              return [true];
-            },
-          });
-
-          it('must delete file before write it', async () => {
-            const baseUrl = 'https://storage.googleapis.com';
-            const url = `${baseUrl}/random-bucket/4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg`;
-
-            const fileData = {
-              ext: '.JPEG',
-              buffer: 'file buffer information',
-              mime: 'image/jpeg',
-              name: 'people coding.JPEG',
-              related: [],
-              hash: '4l0ngH45h',
-              url,
-            };
-
-            const saveExpectedArgs = [
-              'file buffer information',
-              {
-                contentType: 'image/jpeg',
-                metadata: {
-                  contentDisposition: 'inline; filename="people coding.JPEG"',
-                },
-                public: true,
-              },
-            ];
-
-            const fileMock = createFileMock({ saveExpectedArgs });
-            const expectedFileNames = [
-              '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
-              '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
-              '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
-            ];
-            const bucketMock = createBucketMock({ fileMock, expectedFileNames });
-            const Storage = class {
-              bucket(bucketName) {
+              async delete() {
                 assertionsCount += 1;
-                assert.equal(bucketName, 'random-bucket');
-                return bucketMock;
-              }
-            };
-
-            mockRequire('@google-cloud/storage', { Storage });
-            const provider = mockRequire.reRequire('../../lib/provider');
-            const config = {
-              serviceAccount: {
-                project_id: '123',
-                client_email: 'my@email.org',
-                private_key: 'a random key',
+                return true;
               },
-              bucketName: 'random-bucket',
-            };
-            const providerInstance = provider.init(config);
-            await providerInstance.upload(fileData);
-            assert.equal(assertionsCount, 9);
-            mockRequire.stop('@google-cloud/storage');
-          });
-        });
-      });
-    });
-
-    describe('when execute #delete', () => {
-      let assertionsCount;
-
-      describe('when bucket exists', () => {
-        const createBucketMock = ({ fileMock, expectedFileNames }) => ({
-          file(fileName) {
-            assertionsCount += 1;
-            assert.equal(fileName, expectedFileNames.shift());
-            return fileMock;
-          },
-          async exists() {
-            assertionsCount += 1;
-            return [true];
-          },
-        });
-
-        describe('when file is deleted with success', () => {
-          const createFileMock = () => ({
-            async delete() {
-              assertionsCount += 1;
-              return [];
-            },
-          });
-
-          it('must log message and resolve with nothing', async () => {
-            global.strapi.log.debug = (...args) => {
-              assert.deepEqual(args, ['File o/people-working.png successfully deleted']);
-              assertionsCount += 1;
-            };
-            assertionsCount = 0;
-            const expectedFileNames = ['o/people-working.png'];
-            const bucketMock = createBucketMock({ fileMock: createFileMock(), expectedFileNames });
-            mockRequire('@google-cloud/storage', {
-              Storage: class {
-                bucket(bucketName) {
-                  assertionsCount += 1;
-                  assert.equal(bucketName, 'my-bucket');
-                  return bucketMock;
-                }
+              async save(...args) {
+                assertionsCount += 1;
+                assert.deepEqual(args, saveExpectedArgs);
+                return [true];
               },
             });
-            const provider = mockRequire.reRequire('../../lib/provider');
-            const config = {
-              serviceAccount: {
-                project_id: '123',
-                client_email: 'my@email.org',
-                private_key: 'a random key',
-              },
-              bucketName: 'my-bucket',
-            };
-            const providerInstance = provider.init(config);
-            const fileData = {
-              url: 'https://storage.googleapis.com/my-bucket/o/people-working.png',
-            };
-            await assert.doesNotReject(providerInstance.delete(fileData));
-            // TODO: fix this. Probabily a problem with async flows
-            await new Promise((resolve) => setTimeout(resolve, 1));
-            assert.equal(assertionsCount, 4);
-            mockRequire.stop('@google-cloud/storage');
+
+            it('must delete file before write it', async () => {
+              const baseUrl = 'https://storage.googleapis.com';
+              const url = `${baseUrl}/random-bucket/4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg`;
+
+              const fileData = {
+                ext: '.JPEG',
+                buffer: 'file buffer information',
+                mime: 'image/jpeg',
+                name: 'people coding.JPEG',
+                related: [],
+                hash: '4l0ngH45h',
+                url,
+              };
+
+              const saveExpectedArgs = [
+                'file buffer information',
+                {
+                  contentType: 'image/jpeg',
+                  metadata: {
+                    contentDisposition: 'inline; filename="people coding.JPEG"',
+                  },
+                  public: true,
+                },
+              ];
+
+              const fileMock = createFileMock({ saveExpectedArgs });
+              const expectedFileNames = [
+                '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
+                '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
+                '4l0ngH45h/people-coding.JPEG_4l0ngH45h.jpeg',
+              ];
+              const bucketMock = createBucketMock({ fileMock, expectedFileNames });
+              const Storage = class {
+                bucket(bucketName) {
+                  assertionsCount += 1;
+                  assert.equal(bucketName, 'random-bucket');
+                  return bucketMock;
+                }
+              };
+
+              mockRequire('@google-cloud/storage', { Storage });
+              const provider = mockRequire.reRequire('../../lib/provider');
+              const config = {
+                serviceAccount: {
+                  project_id: '123',
+                  client_email: 'my@email.org',
+                  private_key: 'a random key',
+                },
+                bucketName: 'random-bucket',
+                shortFilePaths: shortFilePaths,
+              };
+              const providerInstance = provider.init(config);
+              await providerInstance.upload(fileData);
+              assert.equal(assertionsCount, 9);
+              mockRequire.stop('@google-cloud/storage');
+            });
           });
         });
+      });
 
-        describe('when file cannot be deleted', () => {
-          const createFileMock = ({ errorCode }) => ({
-            async delete() {
+      describe('when execute #delete', () => {
+        let assertionsCount;
+
+        describe('when bucket exists', () => {
+          const createBucketMock = ({ fileMock, expectedFileNames }) => ({
+            file(fileName) {
               assertionsCount += 1;
-              const error = new Error('Error deleting file');
-              error.code = errorCode;
-              throw error;
+              assert.equal(fileName, expectedFileNames.shift());
+              return fileMock;
+            },
+            async exists() {
+              assertionsCount += 1;
+              return [true];
             },
           });
 
-          describe('when error is a 404 error', () => {
-            it('must log message and resolve with nothing', async () => {
-              global.strapi.log.warn = (...args) => {
+          describe('when file is deleted with success', () => {
+            const createFileMock = () => ({
+              async delete() {
                 assertionsCount += 1;
-                assert.deepEqual(args, [
-                  'Remote file was not found, you may have to delete manually.',
-                ]);
+                return [];
+              },
+            });
+
+            it('must log message and resolve with nothing', async () => {
+              global.strapi.log.debug = (...args) => {
+                assert.deepEqual(args, ['File o/people-working.png successfully deleted']);
+                assertionsCount += 1;
               };
-              const errorCode = 404;
               assertionsCount = 0;
               const expectedFileNames = ['o/people-working.png'];
               const bucketMock = createBucketMock({
-                fileMock: createFileMock({ errorCode }),
+                fileMock: createFileMock(),
                 expectedFileNames,
               });
               mockRequire('@google-cloud/storage', {
@@ -694,6 +661,7 @@ describe('/lib/provider.js', () => {
                   private_key: 'a random key',
                 },
                 bucketName: 'my-bucket',
+                shortFilePaths: shortFilePaths,
               };
               const providerInstance = provider.init(config);
               const fileData = {
@@ -707,49 +675,107 @@ describe('/lib/provider.js', () => {
             });
           });
 
-          describe('when error is any other error', () => {
-            it('must reject with problem', async () => {
-              global.strapi.log.warn = (...args) => {
+          describe('when file cannot be deleted', () => {
+            const createFileMock = ({ errorCode }) => ({
+              async delete() {
                 assertionsCount += 1;
-                assert.deepEqual(args, [
-                  'Remote file was not found, you may have to delete manually.',
-                ]);
-              };
-              const errorCode = 500;
-              assertionsCount = 0;
-              const expectedFileNames = ['o/people-working.png'];
-              const bucketMock = createBucketMock({
-                fileMock: createFileMock({ errorCode }),
-                expectedFileNames,
+                const error = new Error('Error deleting file');
+                error.code = errorCode;
+                throw error;
+              },
+            });
+
+            describe('when error is a 404 error', () => {
+              it('must log message and resolve with nothing', async () => {
+                global.strapi.log.warn = (...args) => {
+                  assertionsCount += 1;
+                  assert.deepEqual(args, [
+                    'Remote file was not found, you may have to delete manually.',
+                  ]);
+                };
+                const errorCode = 404;
+                assertionsCount = 0;
+                const expectedFileNames = ['o/people-working.png'];
+                const bucketMock = createBucketMock({
+                  fileMock: createFileMock({ errorCode }),
+                  expectedFileNames,
+                });
+                mockRequire('@google-cloud/storage', {
+                  Storage: class {
+                    bucket(bucketName) {
+                      assertionsCount += 1;
+                      assert.equal(bucketName, 'my-bucket');
+                      return bucketMock;
+                    }
+                  },
+                });
+                const provider = mockRequire.reRequire('../../lib/provider');
+                const config = {
+                  serviceAccount: {
+                    project_id: '123',
+                    client_email: 'my@email.org',
+                    private_key: 'a random key',
+                  },
+                  bucketName: 'my-bucket',
+                  shortFilePaths: shortFilePaths,
+                };
+                const providerInstance = provider.init(config);
+                const fileData = {
+                  url: 'https://storage.googleapis.com/my-bucket/o/people-working.png',
+                };
+                await assert.doesNotReject(providerInstance.delete(fileData));
+                // TODO: fix this. Probabily a problem with async flows
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                assert.equal(assertionsCount, 4);
+                mockRequire.stop('@google-cloud/storage');
               });
-              mockRequire('@google-cloud/storage', {
-                Storage: class {
-                  bucket(bucketName) {
-                    assertionsCount += 1;
-                    assert.equal(bucketName, 'my-bucket');
-                    return bucketMock;
-                  }
-                },
+            });
+
+            describe('when error is any other error', () => {
+              it('must reject with problem', async () => {
+                global.strapi.log.warn = (...args) => {
+                  assertionsCount += 1;
+                  assert.deepEqual(args, [
+                    'Remote file was not found, you may have to delete manually.',
+                  ]);
+                };
+                const errorCode = 500;
+                assertionsCount = 0;
+                const expectedFileNames = ['o/people-working.png'];
+                const bucketMock = createBucketMock({
+                  fileMock: createFileMock({ errorCode }),
+                  expectedFileNames,
+                });
+                mockRequire('@google-cloud/storage', {
+                  Storage: class {
+                    bucket(bucketName) {
+                      assertionsCount += 1;
+                      assert.equal(bucketName, 'my-bucket');
+                      return bucketMock;
+                    }
+                  },
+                });
+                const provider = mockRequire.reRequire('../../lib/provider');
+                const config = {
+                  serviceAccount: {
+                    project_id: '123',
+                    client_email: 'my@email.org',
+                    private_key: 'a random key',
+                  },
+                  bucketName: 'my-bucket',
+                  shortFilePaths: shortFilePaths,
+                };
+                const providerInstance = provider.init(config);
+                const fileData = {
+                  url: 'https://storage.googleapis.com/my-bucket/o/people-working.png',
+                };
+                // FIXME: based on code this must reject. Probabily a problem with async flows
+                await assert.doesNotReject(providerInstance.delete(fileData));
+                // TODO: fix this. Probabily a problem with async flows
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                assert.equal(assertionsCount, 3);
+                mockRequire.stop('@google-cloud/storage');
               });
-              const provider = mockRequire.reRequire('../../lib/provider');
-              const config = {
-                serviceAccount: {
-                  project_id: '123',
-                  client_email: 'my@email.org',
-                  private_key: 'a random key',
-                },
-                bucketName: 'my-bucket',
-              };
-              const providerInstance = provider.init(config);
-              const fileData = {
-                url: 'https://storage.googleapis.com/my-bucket/o/people-working.png',
-              };
-              // FIXME: based on code this must reject. Probabily a problem with async flows
-              await assert.doesNotReject(providerInstance.delete(fileData));
-              // TODO: fix this. Probabily a problem with async flows
-              await new Promise((resolve) => setTimeout(resolve, 1));
-              assert.equal(assertionsCount, 3);
-              mockRequire.stop('@google-cloud/storage');
             });
           });
         });


### PR DESCRIPTION
## New Approach to Filepath Names (See #38)

This version works exactly like the regular one when you don't set the config variable `shortFilePaths` to `true` (everything else will be ignored):
```json
{
  "provider": "google-cloud-storage",
  "providerOptions": {
    "serviceAccount": "${process.env.GCS_SERVICE_ACCOUNT || <Your serviceAccount JSON object/string here>}",
    "bucketName": "${process.env.GCS_BUCKET_NAME || Bucket-name}",
    "baseUrl": "${process.env.GCS_BASE_URL || https://storage.googleapis.com/{bucket-name}}",
    "basePath": "",
    "publicFiles": true,
    "shortFilePaths": true
  }
}
```

I added dedicated tests for all the uses of the new version. However 2/36 tests do not work: With `when file DOES NOT exists in bucket` (L. 464) and `when file exists in bucket` (L. 517) I do not know how to modify the tests for the new version. Could you help me with this @dgmike ? :)

<br/>

---

Example of the **current version** (Each resized version of an image has its own subdirectory):

<img width="864" alt="Bildschirmfoto 2020-06-03 um 21 25 51" src="https://user-images.githubusercontent.com/29046316/83695622-b7a9ff80-a5fa-11ea-887a-0b067e324651.png">

<img width="879" alt="Bildschirmfoto 2020-06-03 um 21 26 16" src="https://user-images.githubusercontent.com/29046316/83695626-bb3d8680-a5fa-11ea-8b76-f6e2ae3db241.png">

<br/>

---

Example of **new version** (Each distict image has its own directory but all resized version are located in the same folder):

<img width="828" alt="Bildschirmfoto 2020-06-03 um 21 27 59" src="https://user-images.githubusercontent.com/29046316/83695788-14a5b580-a5fb-11ea-9488-847ca5ca92ca.png">

<img width="896" alt="Bildschirmfoto 2020-06-03 um 21 28 09" src="https://user-images.githubusercontent.com/29046316/83695792-18393c80-a5fb-11ea-995c-be242cde18da.png">

---

I tried to reduce the number of changed lines in the test file however I had to wrap a few test in a loop to test both versions that is why there are so many "additions".