### PR TITLE
Use google application credentials

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -139,8 +139,14 @@ const init = (providerConfig) => {
     throw new Error('"Bucket name" is required!');
   }
 
-  const GCS;
-  if (config.useEnvCredentials == true && process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  let GCS;
+  // By default, the client will authenticate using the service account file
+  // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
+  // the project specified by the GOOGLE_CLOUD_PROJECT environment variable.
+  // These environment variables are set automatically on Google App Engine
+  // https://cloud.google.com/appengine/docs/flexible/nodejs/using-cloud-storage
+  // https://cloud.google.com/docs/authentication/production#auth-cloud-implicit-nodejs
+  if (config.useEnvCredentials == true) {
     GCS = new Storage()
   } else {
     const serviceAccount = checkServiceAccount(config);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -33,19 +33,6 @@ const checkServiceAccount = (config) => {
   if (!config.serviceAccount) {
     throw new Error('"Service Account JSON" is required!');
   }
-  if (!config.bucketName) {
-    throw new Error('"Bucket name" is required!');
-  }
-  if (!config.baseUrl) {
-    /** Set to default **/
-    config.baseUrl = 'https://storage.googleapis.com/{bucket-name}';
-  }
-  if (!config.basePath) {
-    config.basePath = '';
-  }
-  if (config.publicFiles === undefined) {
-    config.publicFiles = true;
-  }
 
   let serviceAccount;
 
@@ -81,6 +68,22 @@ const checkServiceAccount = (config) => {
 
   return serviceAccount;
 };
+
+/** 
+  * Set defaults, if values not provided in config
+  * @param config
+ */
+const setupDefaults = (config) => {
+  if (!config.baseUrl) {
+    config.baseUrl = 'https://storage.googleapis.com/{bucket-name}';
+  }
+  if (!config.basePath) {
+    config.basePath = '';
+  }
+  if (config.publicFiles === undefined) {
+    config.publicFiles = true;
+  }
+}
 
 /**
  * Check bucket exist, or create it
@@ -132,14 +135,25 @@ const generateUploadFileName = (basePath, file) => {
  */
 const init = (providerConfig) => {
   const config = mergeConfigs(providerConfig);
-  const serviceAccount = checkServiceAccount(config);
-  const GCS = new Storage({
-    projectId: serviceAccount.project_id,
-    credentials: {
-      client_email: serviceAccount.client_email,
-      private_key: serviceAccount.private_key,
-    },
-  });
+  if (!config.bucketName) {
+    throw new Error('"Bucket name" is required!');
+  }
+
+  const GCS;
+  if (config.useEnvCredentials == true && process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    GCS = new Storage()
+  } else {
+    const serviceAccount = checkServiceAccount(config);
+    GCS = new Storage({
+      projectId: serviceAccount.project_id,
+      credentials: {
+        client_email: serviceAccount.client_email,
+        private_key: serviceAccount.private_key,
+      },
+    });
+  }
+
+  setupDefaults(config);
   const basePath = `${config.basePath}/`.replace(/^\/+/, '');
   const baseUrl = config.baseUrl.replace('{bucket-name}', config.bucketName);
 
@@ -190,6 +204,7 @@ const init = (providerConfig) => {
 module.exports = {
   get,
   checkServiceAccount,
+  setupDefaults,
   checkBucket,
   mergeConfigs,
   generateUploadFileName,


### PR DESCRIPTION
Hi,
as specified in https://cloud.google.com/appengine/docs/flexible/nodejs/using-cloud-storage
  and https://cloud.google.com/docs/authentication/production#auth-cloud-implicit-nodejs there is also a way to just specify a bucket name, and App Engine and Compute Engine have the credentials available.
There is also a way to specify `GOOGLE_APPLICATION_CREDENTIALS` when developing locally.
tested so far on App Engine.
If you are ok with the changes, I can update the readme and tests.