### PR TITLE
Automatically use application default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ The bucket should be created with **fine grained** access control, as the plugin
 ### Where my bucket can be located ?
 - https://cloud.google.com/storage/docs/locations
 
-## Setting up Google authentication
+## <a name="setup-auth"></a> Setting up Google authentication
+
+If you are deploying to a Google Cloud Platform product that supports [Application Default Credentials](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically) (such as App Engine, Cloud Run, and Cloud Functions etc.), then you can skip this step. 
+
+If you are deploying outside GCP, then follow these steps to set up authentication:
 
 1. In the GCP Console, go to the **Create service account key** page.. 
     - **[Go to the create service account key page](https://console.cloud.google.com/apis/credentials/serviceaccountkey)**
@@ -39,17 +43,33 @@ The bucket should be created with **fine grained** access control, as the plugin
 4. From the **Role** list, select **Cloud Storage > Storage Admin**.
 5. Select `JSON` for **Key Type**
 6. Click **Create**. A JSON file that contains your key downloads to your computer.
+7. Copy the full content of the downloaded JSON file
+8. Open the Strapi configuration file 
+9. Paste it into the "Service Account JSON" field (as `string` or `JSON`, be careful with indentation)
 
 ## Setting up the a configuration file
 
 You will find below many examples of configurations, for each example :
-1. Copy the full content of the downloaded JSON file
-2. Open the configuration file 
-3. Paste it into the "Service Account JSON" field (as `string` or `JSON`, be careful with indentation)
-4. Set the `bucketName` field and replace `Bucket-name` by yours [previously create](#create-bucket)
-5. Default `baseUrl` is working, but you can replace it by yours (if you use a custom baseUrl)
-6. Save the configuration file
-7. Enjoy !
+
+1. If you are deploying outside GCP, then follow the steps above [Setting up Google authentication](#setup-auth)
+2. Set the `bucketName` field and replace `Bucket-name` by yours [previously create](#create-bucket)
+3. Default `baseUrl` is working, but you can replace it by yours (if you use a custom baseUrl)
+4. Save the configuration file
+5. Enjoy !
+
+**Example with application default credentials (minimal setup)**
+
+This works only for deployment to GCP products such as App Engine, Cloud Run, and Cloud Functions etc.
+
+`./extensions/upload/config/settings.json`
+```json
+{
+  "provider": "google-cloud-storage",
+  "providerOptions": {
+    "bucketName": "Bucket-name"
+  }
+}
+```
 
 **Example with one configuration for all environments (dev/stage/prod)**
 
@@ -158,9 +178,9 @@ Contents of `gcs` key in Strapi custom config, if set, will be merged over `./ex
 
 #### `serviceAccount` :
 
-JSON data provide by Google Account (explained before).
+JSON data provide by Google Account (explained before). If you are deploying to a GCP product that supports Application Default credentials, you can leave this omitted, and authentication will work automatically.
 
-Can be set as a String or JSON Object.
+Can be set as a String, JSON Object, or omitted.
 
 #### `bucketName` :
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -48,35 +48,36 @@ const checkServiceAccount = (config) => {
   }
 
   let serviceAccount;
+  if (config.serviceAccount) {
+    try {
+      serviceAccount =
+        typeof config.serviceAccount === 'string'
+          ? JSON.parse(config.serviceAccount)
+          : config.serviceAccount;
+    } catch (e) {
+      throw new Error(
+        'Error parsing data "Service Account JSON", please be sure to copy/paste the full JSON file.'
+      );
+    }
 
-  try {
-    serviceAccount =
-      typeof config.serviceAccount === 'string'
-        ? JSON.parse(config.serviceAccount)
-        : config.serviceAccount;
-  } catch (e) {
-    throw new Error(
-      'Error parsing data "Service Account JSON", please be sure to copy/paste the full JSON file.'
-    );
-  }
-
-  /**
-   * Check exist
-   */
-  if (!serviceAccount.project_id) {
-    throw new Error(
-      'Error parsing data "Service Account JSON". Missing "project_id" field in JSON file.'
-    );
-  }
-  if (!serviceAccount.client_email) {
-    throw new Error(
-      'Error parsing data "Service Account JSON". Missing "client_email" field in JSON file.'
-    );
-  }
-  if (!serviceAccount.private_key) {
-    throw new Error(
-      'Error parsing data "Service Account JSON". Missing "private_key" field in JSON file.'
-    );
+    /**
+     * Check exist
+     */
+    if (!serviceAccount.project_id) {
+      throw new Error(
+        'Error parsing data "Service Account JSON". Missing "project_id" field in JSON file.'
+      );
+    }
+    if (!serviceAccount.client_email) {
+      throw new Error(
+        'Error parsing data "Service Account JSON". Missing "client_email" field in JSON file.'
+      );
+    }
+    if (!serviceAccount.private_key) {
+      throw new Error(
+        'Error parsing data "Service Account JSON". Missing "private_key" field in JSON file.'
+      );
+    }
   }
 
   return serviceAccount;
@@ -133,13 +134,21 @@ const generateUploadFileName = (basePath, file) => {
 const init = (providerConfig) => {
   const config = mergeConfigs(providerConfig);
   const serviceAccount = checkServiceAccount(config);
-  const GCS = new Storage({
-    projectId: serviceAccount.project_id,
-    credentials: {
-      client_email: serviceAccount.client_email,
-      private_key: serviceAccount.private_key,
-    },
-  });
+  let GCS;
+  if (serviceAccount) {
+    // Provide service account credentials
+    GCS = new Storage({
+      projectId: serviceAccount.project_id,
+      credentials: {
+        client_email: serviceAccount.client_email,
+        private_key: serviceAccount.private_key,
+      },
+    });
+  } else {
+    // Storage will attempt to find Application Default Credentials
+    GCS = new Storage();
+  }
+  
   const basePath = `${config.basePath}/`.replace(/^\/+/, '');
   const baseUrl = config.baseUrl.replace('{bucket-name}', config.bucketName);
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -29,10 +29,7 @@ const get = (obj, path, defaultValue = undefined) => {
  * @param config
  * @returns {{private_key}|{client_email}|{project_id}|any}
  */
-const checkServiceAccount = (config) => {
-  if (!config.serviceAccount) {
-    throw new Error('"Service Account JSON" is required!');
-  }
+const checkServiceAccount = (config = {}) => {
   if (!config.bucketName) {
     throw new Error('"Bucket name" is required!');
   }

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -11,34 +11,13 @@ const {
 describe('/lib/provider.js', () => {
   describe('#checkServiceAccount', () => {
     describe('when config is invalid', () => {
-      it('must throw error for undefined', () => {
-        const error = new TypeError("Cannot read property 'serviceAccount' of undefined");
+      
+      it('must throw error "Bucket name" is required!', () => {
+        const error = new Error('"Bucket name" is required!');
         assert.throws(() => checkServiceAccount(), error);
       });
 
-      it('must throw error "Service Account JSON" is required!', () => {
-        const config = {};
-        const error = new Error('"Service Account JSON" is required!');
-        assert.throws(() => checkServiceAccount(config), error);
-      });
-
-      it('must throw error "Service Account JSON" is required! for empty value', () => {
-        const config = {
-          serviceAccount: '',
-        };
-        const error = new Error('"Service Account JSON" is required!');
-        assert.throws(() => checkServiceAccount(config), error);
-      });
-
-      it('must throw error "Bucket name" is required!', () => {
-        const config = {
-          serviceAccount: {},
-        };
-        const error = new Error('"Bucket name" is required!');
-        assert.throws(() => checkServiceAccount(config), error);
-      });
-
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: "I'm not a valid JSON",
           bucketName: 'some-bucket',
@@ -49,7 +28,7 @@ describe('/lib/provider.js', () => {
         assert.throws(() => checkServiceAccount(config), error);
       });
 
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: {},
           bucketName: 'some-bucket',
@@ -60,7 +39,7 @@ describe('/lib/provider.js', () => {
         assert.throws(() => checkServiceAccount(config), error);
       });
 
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: {},
           bucketName: 'some-bucket',
@@ -71,7 +50,7 @@ describe('/lib/provider.js', () => {
         assert.throws(() => checkServiceAccount(config), error);
       });
 
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: {
             project_id: '123',
@@ -84,7 +63,7 @@ describe('/lib/provider.js', () => {
         assert.throws(() => checkServiceAccount(config), error);
       });
 
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: {
             project_id: '123',
@@ -98,7 +77,7 @@ describe('/lib/provider.js', () => {
         assert.throws(() => checkServiceAccount(config), error);
       });
 
-      it('must throw error when serviceAccount does not accoplish with correct values', () => {
+      it('must throw error when serviceAccount does not accomplish with correct values', () => {
         const config = {
           serviceAccount: `{"project_id": "123", "client_email": "my@email.org"}`,
           bucketName: 'some-bucket',
@@ -111,6 +90,13 @@ describe('/lib/provider.js', () => {
     });
 
     describe('when config is valid', () => {
+      it('must accept minimal configuration without errors', () => {
+        const config = {
+          bucketName: 'some-bucket',
+        };
+        checkServiceAccount(config);
+      });
+      
       it('must accept configurations without errors', () => {
         const config = {
           serviceAccount: {


### PR DESCRIPTION
Alternative implementation to #54. 

Instead of introducing a new flag for using default credentials, just automatically revert to default credentials when no service account credentials are provided.

Now, the only required configuration is `bucketName`, and everything will work out of the box when deployed on GCP products supporting default credentials.

Closes #55.