### PR TITLE
Fixes #37

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -44,6 +44,10 @@ const checkServiceAccount = (config = {}) => {
     config.publicFiles = true;
   }
 
+  if (!config.uniform) {
+    config.uniform = false;
+  }
+
   let serviceAccount;
   if (config.serviceAccount) {
     try {
@@ -165,11 +169,13 @@ const init = (providerConfig) => {
         }
         const fileAttributes = {
           contentType: file.mime,
-          public: config.publicFiles,
           metadata: {
             contentDisposition: `inline; filename="${file.name}"`,
           },
         };
+        if (!config.uniform) {
+          fileAttributes.public = config.publicFiles;
+        }
         await bucketFile.save(file.buffer, fileAttributes);
         file.url = `${baseUrl}/${fullFileName}`;
         strapi.log.debug(`File successfully uploaded to ${file.url}`);


### PR DESCRIPTION
Adds a simple config called 'uniform' which lets you upload without setting fileAttributes.public which gets around the error on uniform permissions
```error Error uploading file to Google Cloud Storage: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled```