### PR TITLE
Fixes #38 - Adds a new generateUploadFileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Boolean to define uniform access, when uniform bucket-level access is enabled
 - Default value : `false`
 - Optional
 
+#### `oldFilePaths`:
+
+Boolean to use the old file path method. Probably only needed on existing projects.
+- Default value : `false`
+- Optional
+
 ## FAQ
 
 ### Common errors

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -44,6 +44,10 @@ const checkServiceAccount = (config = {}) => {
     config.publicFiles = true;
   }
 
+  if (!config.uniform) {
+    config.uniform = false;
+  }
+
   let serviceAccount;
   if (config.serviceAccount) {
     try {
@@ -165,11 +169,13 @@ const init = (providerConfig) => {
         }
         const fileAttributes = {
           contentType: file.mime,
-          public: config.publicFiles,
           metadata: {
             contentDisposition: `inline; filename="${file.name}"`,
           },
         };
+        if (!config.uniform) {
+          fileAttributes.public = config.publicFiles;
+        }
         await bucketFile.save(file.buffer, fileAttributes);
         file.url = `${baseUrl}/${fullFileName}`;
         strapi.log.debug(`File successfully uploaded to ${file.url}`);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -48,6 +48,10 @@ const checkServiceAccount = (config = {}) => {
     config.uniform = false;
   }
 
+  if (!config.oldFilePaths) {
+    config.oldFilePaths = false;
+  }
+
   let serviceAccount;
   if (config.serviceAccount) {
     try {
@@ -112,13 +116,13 @@ const mergeConfigs = (providerConfig) => {
 };
 
 /**
- * Generate upload filename including path
+ * Old Generate upload filename including path method, uses config.oldFilePaths = true
  *
  * @param basePath
  * @param file
  * @returns string
  */
-const generateUploadFileName = (basePath, file) => {
+const oldGenerateUploadFileName = (basePath, file) => {
   const backupPath =
     file.related && file.related.length > 0 && file.related[0].ref
       ? `${file.related[0].ref}`
@@ -127,6 +131,18 @@ const generateUploadFileName = (basePath, file) => {
   const extension = file.ext.toLowerCase();
   const fileName = slugify(path.basename(file.name + '_' + file.hash, file.ext)) + extension;
   return `${basePath}${filePath}${fileName}`;
+};
+
+/**
+ * Generate upload filename including path
+ *
+ * @param basePath
+ * @param file
+ * @returns string
+ */
+const generateUploadFileName = (basePath, file) => {
+  const path = file.path ? `${file.path}/` : '';
+  return `${basePath}${path}${file.hash}${file.ext}`;
 };
 
 /**
@@ -158,7 +174,7 @@ const init = (providerConfig) => {
   return {
     async upload(file) {
       try {
-        const fullFileName = generateUploadFileName(basePath, file);
+        const fullFileName = config.oldFilePaths ? oldGenerateUploadFileName(basePath, file) : generateUploadFileName(basePath, file);
         await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);
@@ -208,6 +224,7 @@ module.exports = {
   checkServiceAccount,
   checkBucket,
   mergeConfigs,
+  oldGenerateUploadFileName,
   generateUploadFileName,
   init,
 };


### PR DESCRIPTION
This adds a new generateUploadFileName using the same "standard" that is used in the official strapi upload plugins (i.e. aws). It offers the option of setting `config.oldFilePaths` which will continue using the old method for backwards compatibility. May be considered a breaking change for existing users but 100% better for us new users :)