### PR TITLE
Change documention with env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ module.exports = ({ env }) => ({
     upload: {
       provider: 'google-cloud-storage',
       providerOptions: {
-        serviceAccount: env('GCS_SERVICE_ACCOUNT'),
+        serviceAccount: env.json('GCS_SERVICE_ACCOUNT'),
         bucketName: env('GCS_BUCKET_NAME'),
         basePath: env('GCS_BASE_PATH'),
         baseUrl: env('GCS_BASE_URL'),


### PR DESCRIPTION
(This is my first PR in github 😅)

For better documentation, It is better to cast the service account json as a json with `env.json()`
It worked for me, because as a copy paste on your example didn't work.