### PR TITLE
Make metadata fully configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,33 @@ Boolean to define uniform access, when uniform bucket-level access is enabled
 - Default value : `false`
 - Optional
 
+### `metadata`:
+
+Function that is executed to compute the metadata for a file when it is uploaded. 
+
+When no function is provided, the following metadata is used:
+
+```json
+{
+  contentDisposition: `inline; filename="${file.name}"`,
+}
+```
+
+- Default value: `undefined`
+- Optional
+
+Example:
+
+```js
+  metadata: (file) => ({
+    cacheControl: `public, max-age=${60 * 60 * 24 * 7}`, // One week
+    contentLanguage: 'en-US',
+    contentDisposition: `attachment; filename="${file.name}"`,
+  }),
+```
+
+The available properties can be found in the [Cloud Storage JSON API documentation](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON).
+
 ## FAQ
 
 ### Common errors

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Function that is executed to compute the metadata for a file when it is uploaded
 
 When no function is provided, the following metadata is used:
 
-```json
+```js
 {
   contentDisposition: `inline; filename="${file.name}"`,
 }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -169,9 +169,12 @@ const init = (providerConfig) => {
         }
         const fileAttributes = {
           contentType: file.mime,
-          metadata: {
-            contentDisposition: `inline; filename="${file.name}"`,
-          },
+          metadata:
+            typeof config.metadata === 'function'
+              ? config.metadata(file)
+              : {
+                  contentDisposition: `inline; filename="${file.name}"`,
+                },
         };
         if (!config.uniform) {
           fileAttributes.public = config.publicFiles;

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -11,7 +11,6 @@ const {
 describe('/lib/provider.js', () => {
   describe('#checkServiceAccount', () => {
     describe('when config is invalid', () => {
-
       it('must throw error "Bucket name" is required!', () => {
         const error = new Error('"Bucket name" is required!');
         assert.throws(() => checkServiceAccount(), error);
@@ -443,21 +442,21 @@ describe('/lib/provider.js', () => {
             },
           });
 
-          it('must save file', async () => {
-            const fileData = {
-              ext: '.JPEG',
-              buffer: 'file buffer information',
-              mime: 'image/jpeg',
-              name: 'people coding.JPEG',
-              related: [
-                {
-                  ref: 'ref',
-                },
-              ],
-              hash: '4l0ngH45h',
-              path: '/tmp/strapi',
-            };
+          const fileData = {
+            ext: '.JPEG',
+            buffer: 'file buffer information',
+            mime: 'image/jpeg',
+            name: 'people coding.JPEG',
+            related: [
+              {
+                ref: 'ref',
+              },
+            ],
+            hash: '4l0ngH45h',
+            path: '/tmp/strapi',
+          };
 
+          it('must save file', async () => {
             const saveExpectedArgs = [
               'file buffer information',
               {
@@ -470,10 +469,7 @@ describe('/lib/provider.js', () => {
             ];
 
             const fileMock = createFileMock({ saveExpectedArgs });
-            const expectedFileNames = [
-              '/tmp/strapi/4l0ngH45h.jpeg',
-              '/tmp/strapi/4l0ngH45h.jpeg',
-            ];
+            const expectedFileNames = ['/tmp/strapi/4l0ngH45h.jpeg', '/tmp/strapi/4l0ngH45h.jpeg'];
             const bucketMock = createBucketMock({ fileMock, expectedFileNames });
             const Storage = class {
               bucket(bucketName) {
@@ -492,6 +488,52 @@ describe('/lib/provider.js', () => {
                 private_key: 'a random key',
               },
               bucketName: 'any bucket',
+            };
+            const providerInstance = provider.init(config);
+            await providerInstance.upload(fileData);
+            assert.equal(assertionsCount, 6);
+            mockRequire.stop('@google-cloud/storage');
+          });
+
+          it('must save file with custom metadata', async () => {
+            const saveExpectedArgs = [
+              'file buffer information',
+              {
+                contentType: 'image/jpeg',
+                metadata: {
+                  cacheControl: 'public, max-age=604800',
+                  contentLanguage: 'en-US',
+                  contentDisposition: 'attachment; filename="people coding.JPEG"',
+                },
+                public: true,
+              },
+            ];
+
+            const fileMock = createFileMock({ saveExpectedArgs });
+            const expectedFileNames = ['/tmp/strapi/4l0ngH45h.jpeg', '/tmp/strapi/4l0ngH45h.jpeg'];
+            const bucketMock = createBucketMock({ fileMock, expectedFileNames });
+            const Storage = class {
+              bucket(bucketName) {
+                assertionsCount += 1;
+                assert.equal(bucketName, 'any bucket');
+                return bucketMock;
+              }
+            };
+
+            mockRequire('@google-cloud/storage', { Storage });
+            const provider = mockRequire.reRequire('../../lib/provider');
+            const config = {
+              serviceAccount: {
+                project_id: '123',
+                client_email: 'my@email.org',
+                private_key: 'a random key',
+              },
+              bucketName: 'any bucket',
+              metadata: (file) => ({
+                cacheControl: `public, max-age=${60 * 60 * 24 * 7}`, // One week
+                contentLanguage: 'en-US',
+                contentDisposition: `attachment; filename="${file.name}"`,
+              }),
             };
             const providerInstance = provider.init(config);
             await providerInstance.upload(fileData);


### PR DESCRIPTION
I wanted to use more metadata fields than were configurable. One of them was the `cacheControl` which was added by @KuschL in https://github.com/Lith/strapi-provider-upload-google-cloud-storage/pull/86, but I also wanted to add others and 'unset' [the hard-coded contentDisposition property](https://github.com/Lith/strapi-provider-upload-google-cloud-storage/blob/f7b6167920906d71d883f8b36cce9e9d7c3fe9f4/lib/provider.js#L172-L174).

The solution in this PR is more generic than the one in https://github.com/Lith/strapi-provider-upload-google-cloud-storage/pull/86 and I think it can replace that solution. @KuschL: what is your opinion?