### PR TITLE
Add support for custom generate upload file name method

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ Boolean to define uniform access, when uniform bucket-level access is enabled
 - Default value : `false`
 - Optional
 
+### `generateUploadFileName`:
+
+Function that is executed to generate the name of the uploaded file. This method can give more control over the file name and can for example be used to include a custom hashing function or dynamic path.
+
+When no function is provided, the [default algorithm](lib/provider.js) is used.
+
+- Default value: `undefined`
+- Optional
+
+Example:
+
+```js
+  generateUploadFileName: (file) => {
+    const hash = ...; // Some hashing function, for example MD-5
+    const extension = file.ext.toLowerCase().substring(1);
+    return `${extension}/${slugify(path.parse(file.name).name)}-${hash}.${extension}`;
+  },
+```
+
 ## FAQ
 
 ### Common errors

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -158,7 +158,10 @@ const init = (providerConfig) => {
   return {
     async upload(file) {
       try {
-        const fullFileName = generateUploadFileName(basePath, file);
+        const fullFileName =
+          typeof config.generateUploadFileName === 'function'
+            ? config.generateUploadFileName(file)
+            : generateUploadFileName(basePath, file);
         await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);


### PR DESCRIPTION
This enables more control over the file name generation. Inspired by the issues from https://github.com/Lith/strapi-provider-upload-google-cloud-storage/issues/82, but it does not solve them. One can use dynamic paths base on properties of the file though.

Examples, test and documentation is included.

:+1: for creating this plugin.