### PR TITLE
Make gzip configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,21 @@ Boolean to define a public attribute to file when it upload to storage.
 
 #### `uniform`:
 
-Boolean to define uniform access, when uniform bucket-level access is enabled
+Boolean to define uniform access, when uniform bucket-level access is enabled.
 - Default value : `false`
 - Optional
 
 #### `cacheMaxAge`:
 
-Number to set the cache-control header for uploaded files
+Number to set the cache-control header for uploaded files.
 - Default value : `3600`
+- Optional
+
+#### `gzip`:
+
+Value to define if files are uploaded and stored with gzip compression.
+- Possible values: `true`, `false`, `auto`
+- Default value : `auto`
 - Optional
 
 ### `metadata`:

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -172,7 +172,7 @@ const init = (providerConfig) => {
         }
         const fileAttributes = {
           contentType: file.mime,
-          gzip: 'auto', // enables gzip for non-binary files like svg
+          gzip: typeof config.gzip === 'boolean' ? config.gzip : 'auto',
           metadata:
             typeof config.metadata === 'function'
               ? config.metadata(file)

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -593,6 +593,48 @@ describe('/lib/provider.js', () => {
             assert.equal(assertionsCount, 6);
             mockRequire.stop('@google-cloud/storage');
           });
+
+          it('must save file with forced gzip', async () => {
+            const saveExpectedArgs = [
+              'file buffer information',
+              {
+                contentType: 'image/jpeg',
+                gzip: true,
+                metadata: {
+                  cacheControl: 'public, max-age=3600',
+                  contentDisposition: 'inline; filename="people coding.JPEG"',
+                },
+                public: true,
+              },
+            ];
+
+            const fileMock = createFileMock({ saveExpectedArgs });
+            const expectedFileNames = ['/tmp/strapi/4l0ngH45h.jpeg', '/tmp/strapi/4l0ngH45h.jpeg'];
+            const bucketMock = createBucketMock({ fileMock, expectedFileNames });
+            const Storage = class {
+              bucket(bucketName) {
+                assertionsCount += 1;
+                assert.equal(bucketName, 'any bucket');
+                return bucketMock;
+              }
+            };
+
+            mockRequire('@google-cloud/storage', { Storage });
+            const provider = mockRequire.reRequire('../../lib/provider');
+            const config = {
+              serviceAccount: {
+                project_id: '123',
+                client_email: 'my@email.org',
+                private_key: 'a random key',
+              },
+              bucketName: 'any bucket',
+              gzip: true,
+            };
+            const providerInstance = provider.init(config);
+            await providerInstance.upload(fileData);
+            assert.equal(assertionsCount, 6);
+            mockRequire.stop('@google-cloud/storage');
+          });
         });
 
         describe('when file exists in bucket', () => {


### PR DESCRIPTION
The Google storage package [uses](https://github.com/googleapis/nodejs-storage/blob/390469a2283fd85ee3e1121d77505e77e16dbf10/src/file.ts#L1750-L1752) [compressible](https://www.npmjs.com/package/compressible) to automatically determine if a file can be gzipped.

Using this PR it is possible to forcibly enable or disable gzip compression for all files. This can come in handy with files that contain both binary and text-data or files that have an unknown mime type (and thus fall back to `application/octect-stream`).