### PR TITLE
Add support for custom content type determination

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,27 @@ Example:
   },
 ```
 
+### `getContentType`:
+
+Function that is executed to get the content type of the uploaded file.
+
+When no function is provided, the default content type of the file (`file.mime` is used).
+
+- Default value: `undefined`
+- Optional
+
+Example:
+
+```js
+  getContentType: (file) => {
+    switch ((file && file.ext || '').toLowerCase()) {
+      case '.avif':
+        return 'image/avif';
+      default:
+        return file.mime;
+    }
+  },
+```
 
 ## FAQ
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const slugify = require('slugify');
-const {Storage} = require('@google-cloud/storage');
+const { Storage } = require('@google-cloud/storage');
 
 /**
  * lodash _.get native port
@@ -108,7 +108,7 @@ const checkBucket = async (GCS, bucketName) => {
 const mergeConfigs = (providerConfig) => {
   const customGcsConfig = get(strapi, 'config.gcs', {});
   const customEnvGcsConfig = get(strapi, 'config.currentEnvironment.gcs', {});
-  return {...providerConfig, ...customGcsConfig, ...customEnvGcsConfig};
+  return { ...providerConfig, ...customGcsConfig, ...customEnvGcsConfig };
 };
 
 /**
@@ -178,9 +178,9 @@ const init = (providerConfig) => {
             typeof config.metadata === 'function'
               ? config.metadata(file)
               : {
-                contentDisposition: `inline; filename="${file.name}"`,
-                cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
-              },
+                  contentDisposition: `inline; filename="${file.name}"`,
+                  cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
+                },
         };
         if (!config.uniform) {
           fileAttributes.public = config.publicFiles;

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -171,7 +171,8 @@ const init = (providerConfig) => {
           await this.delete(file);
         }
         const fileAttributes = {
-          contentType: file.mime,
+          contentType:
+            typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,
           gzip: typeof config.gzip === 'boolean' ? config.gzip : 'auto',
           metadata:
             typeof config.metadata === 'function'


### PR DESCRIPTION
I think this is the last PR of a small series of PRs.

For certain newer file types `file.mime` returns `application/octet-stream`. Using this function you can provide your own content types.