### PR TITLE
Added possibility for uploading from URLs

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const got = require('got');
+const { promisify } = require('util');
+const stream = require('stream');
 const path = require('path');
 const slugify = require('slugify');
-const {Storage} = require('@google-cloud/storage');
+const { Storage } = require('@google-cloud/storage');
 
 /**
  * lodash _.get native port
@@ -108,7 +111,7 @@ const checkBucket = async (GCS, bucketName) => {
 const mergeConfigs = (providerConfig) => {
   const customGcsConfig = get(strapi, 'config.gcs', {});
   const customEnvGcsConfig = get(strapi, 'config.currentEnvironment.gcs', {});
-  return {...providerConfig, ...customGcsConfig, ...customEnvGcsConfig};
+  return { ...providerConfig, ...customGcsConfig, ...customEnvGcsConfig };
 };
 
 /**
@@ -177,14 +180,32 @@ const init = (providerConfig) => {
             typeof config.metadata === 'function'
               ? config.metadata(file)
               : {
-                contentDisposition: `inline; filename="${file.name}"`,
-                cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
-              },
+                  contentDisposition: `inline; filename="${fullFileName}"`,
+                  cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
+                },
         };
         if (!config.uniform) {
           fileAttributes.public = config.publicFiles;
         }
-        await bucketFile.save(file.buffer, fileAttributes);
+
+        if (file.buffer.length < 200 && (file.buffer.toString('ascii', 0, 4) === 'http')) {
+          //We're treating it as a url
+
+          const uploadUrl = file.buffer.toString('ascii');
+          const uploadStream = got.stream(uploadUrl);
+
+          fileAttributes.resumable = false;
+          const blobStream = bucketFile.createWriteStream(fileAttributes);
+
+          console.debug(`Uploading file from ${uploadUrl}`);
+          // Need to promisify a pipeline to forward errors, see https://github.com/sindresorhus/got#streams
+          const pipeline = promisify(stream.pipeline);
+          await pipeline(uploadStream, blobStream);
+        } else {
+          //It's a file
+          await bucketFile.save(file.buffer, fileAttributes);
+        }
+
         file.url = `${baseUrl}/${fullFileName}`;
         console.debug(`File successfully uploaded to ${file.url}`);
       } catch (error) {


### PR DESCRIPTION
Hi @Lith . Thanks for making the google cloud storage provider. To support large files I wanted to support reading from external URLs. I found this to be the minimal change needed. Now you can just populate the [files]-array of the upload requests with URLs, or just files or a combination thereof.

Creating thumbnails is not supported with upload from URL. This is on purpose (as it would require loading the entire file into memory).

Using streams to avoid intermediate storage or filling up memory (to support big files)