### PR TITLE
Add option to Skip the Bucket Check

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -162,7 +162,7 @@ const init = (providerConfig) => {
           typeof config.generateUploadFileName === 'function'
             ? config.generateUploadFileName(file)
             : generateUploadFileName(basePath, file);
-        await checkBucket(GCS, config.bucketName);
+        // await checkBucket(GCS, config.bucketName);
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);
         const [fileExists] = await bucketFile.exists();

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const slugify = require('slugify');
-const {Storage} = require('@google-cloud/storage');
+const { Storage } = require('@google-cloud/storage');
 
 /**
  * lodash _.get native port
@@ -43,7 +43,6 @@ const checkServiceAccount = (config = {}) => {
   if (config.publicFiles === undefined) {
     config.publicFiles = true;
   }
-
   if (!config.uniform) {
     config.uniform = false;
   }
@@ -111,7 +110,7 @@ const checkBucket = async (GCS, bucketName) => {
 const mergeConfigs = (providerConfig) => {
   const customGcsConfig = get(strapi, 'config.gcs', {});
   const customEnvGcsConfig = get(strapi, 'config.currentEnvironment.gcs', {});
-  return {...providerConfig, ...customGcsConfig, ...customEnvGcsConfig};
+  return { ...providerConfig, ...customGcsConfig, ...customEnvGcsConfig };
 };
 
 /**
@@ -165,7 +164,7 @@ const init = (providerConfig) => {
           typeof config.generateUploadFileName === 'function'
             ? config.generateUploadFileName(file)
             : generateUploadFileName(basePath, file);
-        if (!config.checkBucket) {
+        if (!config.skipCheckBucket) {
           await checkBucket(GCS, config.bucketName);
         }
         const bucket = GCS.bucket(config.bucketName);
@@ -182,9 +181,9 @@ const init = (providerConfig) => {
             typeof config.metadata === 'function'
               ? config.metadata(file)
               : {
-                contentDisposition: `inline; filename="${file.name}"`,
-                cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
-              },
+                  contentDisposition: `inline; filename="${file.name}"`,
+                  cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
+                },
         };
         if (!config.uniform) {
           fileAttributes.public = config.publicFiles;

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -47,6 +47,9 @@ const checkServiceAccount = (config = {}) => {
   if (!config.uniform) {
     config.uniform = false;
   }
+  if (!config.skipCheckBucket) {
+    config.skipCheckBucket = false;
+  }
 
   let serviceAccount;
   if (config.serviceAccount) {
@@ -162,7 +165,9 @@ const init = (providerConfig) => {
           typeof config.generateUploadFileName === 'function'
             ? config.generateUploadFileName(file)
             : generateUploadFileName(basePath, file);
-        // await checkBucket(GCS, config.bucketName);
+        if (!config.checkBucket) {
+          await checkBucket(GCS, config.bucketName);
+        }
         const bucket = GCS.bucket(config.bucketName);
         const bucketFile = bucket.file(fullFileName);
         const [fileExists] = await bucketFile.exists();


### PR DESCRIPTION
We ran into issues using this plugin as the bucket check requires permissions on the cloud storage that we don't want to give to the service account we're using with strapi for uploading files.

Therefore we have added an option to the plugin that allows you to skip the bucket check.