### PR TITLE
fix: Issue #208 - cacheMaxAge value not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ module.exports = {
 };
 ```
 
-**Note**: If you provide a custom `metadata` function, the `cacheMaxAge` option will not be used automatically. You'll need to handle caching in your custom metadata function if needed.
+**Note**: If you provide a custom `metadata` function, the `cacheMaxAge` option will be ignored. You'll need to handle caching in your custom metadata function if needed.
 
 #### `gzip`:
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Boolean to define `skipCheckBucket`, when skipCheckBucket is enabled, we skip to
 
 #### `cacheMaxAge`:
 
-Number to set the cache-control header for uploaded files in seconds. This value is used by the default metadata function to set the `cacheControl` header as `public, max-age=${cacheMaxAge}`.
+Number to set the cache-control header for uploaded files in seconds. This value is used by the default metadata function to set the `Cache-Control` header as `public, max-age=${cacheMaxAge}`.
 
 - Default value : `3600` (1 hour)
 - Optional

--- a/README.md
+++ b/README.md
@@ -240,9 +240,28 @@ Boolean to define `skipCheckBucket`, when skipCheckBucket is enabled, we skip to
 
 #### `cacheMaxAge`:
 
-Number to set the cache-control header for uploaded files.
-- Default value : `3600`
+Number to set the cache-control header for uploaded files in seconds. This value is used by the default metadata function to set the `cacheControl` header as `public, max-age=${cacheMaxAge}`.
+
+- Default value : `3600` (1 hour)
 - Optional
+
+Example:
+
+```js
+module.exports = {
+  upload: {
+    config: {
+      provider: '@strapi-community/strapi-provider-upload-google-cloud-storage',
+      providerOptions: {
+        bucketName: 'my-bucket',
+        cacheMaxAge: 604800, // 7 days in seconds
+      },
+    },
+  },
+};
+```
+
+**Note**: If you provide a custom `metadata` function, the `cacheMaxAge` option will not be used automatically. You'll need to handle caching in your custom metadata function if needed.
 
 #### `gzip`:
 
@@ -264,12 +283,12 @@ Value to define expiration time for signed URLS. Files are signed when `publicFi
 
 Function that is executed to compute the metadata for a file when it is uploaded. 
 
-When no function is provided, the following metadata is used:
+When no function is provided, the following metadata is used (using the configured `cacheMaxAge` value):
 
 ```ts
 {
   contentDisposition: `inline; filename="${file.name}"`,
-  cacheControl: `public, max-age=3600`,
+  cacheControl: `public, max-age=${cacheMaxAge}`, // Uses the cacheMaxAge from your configuration
 }
 ```
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -48,6 +48,46 @@ describe('Utils', () => {
       const config = getConfigDefaultValues(options);
       expect(config).toEqual(options);
     });
+    test('Sets default cacheMaxAge to 3600 when not provided', () => {
+      const config = getConfigDefaultValues({
+        bucketName: defaultOptions.bucketName,
+      });
+      expect(config.cacheMaxAge).toEqual(3600);
+    });
+    test('Preserves custom cacheMaxAge when provided', () => {
+      const config = getConfigDefaultValues({
+        bucketName: defaultOptions.bucketName,
+        cacheMaxAge: 7200,
+      });
+      expect(config.cacheMaxAge).toEqual(7200);
+    });
+    test('Sets default cacheMaxAge when undefined is provided', () => {
+      const config = getConfigDefaultValues({
+        bucketName: defaultOptions.bucketName,
+        cacheMaxAge: undefined,
+      });
+      expect(config.cacheMaxAge).toEqual(3600);
+    });
+    test('Sets default metadata function that uses cacheMaxAge', () => {
+      const config = getConfigDefaultValues({
+        bucketName: defaultOptions.bucketName,
+        cacheMaxAge: 1800,
+      });
+      
+      const file = {
+        name: 'test.jpg',
+        mime: 'image/jpeg',
+        hash: 'testhash',
+        size: 1000,
+        sizeInBytes: 1000,
+        url: 'test.jpg',
+      };
+      
+      expect(config.metadata).toBeDefined();
+      const metadata = config.metadata!(file);
+      expect(metadata.cacheControl).toEqual('public, max-age=1800');
+      expect(metadata.contentDisposition).toEqual('inline; filename="test.jpg"');
+    });
     test('Throws an error if bucket name is not present', () => {
       // @ts-expect-error Test wrong configuration
       const functionWithoutBucketName = () => getConfigDefaultValues({});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -73,7 +73,7 @@ describe('Utils', () => {
         bucketName: defaultOptions.bucketName,
         cacheMaxAge: 1800,
       });
-      
+
       const file = {
         name: 'test.jpg',
         mime: 'image/jpeg',
@@ -82,7 +82,7 @@ describe('Utils', () => {
         sizeInBytes: 1000,
         url: 'test.jpg',
       };
-      
+
       expect(config.metadata).toBeDefined();
       const metadata = config.metadata!(file);
       expect(metadata.cacheControl).toEqual('public, max-age=1800');

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,14 +64,6 @@ type MetadataFn = (file: File) => FileMetadata;
 type GetContentTypeFn = (file: File) => string;
 type GenerateUploadFileNameFn = (basePath: string, file: File) => Promise<string> | string;
 
-const defaultGetMetadata = (file: File) => {
-  const asciiFileName = file.name.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
-  return {
-    contentDisposition: `inline; filename="${asciiFileName}"`,
-    cacheControl: 'public, max-age=3600',
-  };
-};
-
 const defaultGetContentType = (file: File) => file.mime;
 
 const defaultGenerateUploadFileName = (basePath: string, file: File) => {
@@ -121,8 +113,7 @@ export const optionsSchema = z.object({
     .default(15 * 60 * 1000),
   metadata: z
     .custom<MetadataFn>((val) => typeof val === 'function')
-    .optional()
-    .default(() => defaultGetMetadata),
+    .optional(),
   getContentType: z
     .custom<GetContentTypeFn>((val) => typeof val === 'function')
     .optional()

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,9 +111,7 @@ export const optionsSchema = z.object({
         .max(1000 * 60 * 60 * 24 * 7),
     ])
     .default(15 * 60 * 1000),
-  metadata: z
-    .custom<MetadataFn>((val) => typeof val === 'function')
-    .optional(),
+  metadata: z.custom<MetadataFn>((val) => typeof val === 'function').optional(),
   getContentType: z
     .custom<GetContentTypeFn>((val) => typeof val === 'function')
     .optional()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import {
 export const getConfigDefaultValues = (config: DefaultOptions) => {
   try {
     const parsedConfig = optionsSchema.parse(config);
-    
+
     // If no custom metadata function is provided, use the default one with the configured cacheMaxAge
     if (!config.metadata) {
       const defaultGetMetadata = (cacheMaxAge: number) => (file: File) => {
@@ -23,7 +23,7 @@ export const getConfigDefaultValues = (config: DefaultOptions) => {
       };
       parsedConfig.metadata = defaultGetMetadata(parsedConfig.cacheMaxAge);
     }
-    
+
     return parsedConfig;
   } catch (err) {
     if (err instanceof z.ZodError) {


### PR DESCRIPTION
# Pull Request

## 📝 Description
Implement handling of `cacheMaxAge` value, while keeping the default as `3600`.

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have read and agree with the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My changes follow the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## 🔗 Related Issues
Closes #208